### PR TITLE
Document Angular 17 target and upgrade approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,11 +200,13 @@ Advanced dashboarding and analytics.
 
 API-based triggers for matching (Epic 1).
 
-# Technology Stack:
+# Technology Stack
 
-Backend: Java, Spring Boot.
-Database: MariaDB.
-Frontend: Angular.
-Authentication: JWT (JSON Web Tokens) for stateless authentication.
-Styling: A modern UI library. Please recommend one and we will proceed.
+| Layer | Technology | Notes |
+| --- | --- | --- |
+| Backend | Java (Spring Boot) | Microservice-ready backend for the reconciliation engine and APIs. |
+| Database | MariaDB | Stores configuration, reconciliation runs, and audit data. |
+| Frontend | Angular 17 | Targeting Angular 17 to leverage the current LTS feature set and stability. We will monitor Angular release announcements and use the Angular Update Guide to assess compatibility as new major versions ship, scheduling upgrades in a hardening sprint once dependencies and automated tests pass on the new release. |
+| Authentication | JWT (JSON Web Tokens) | Enables stateless authentication across services. |
+| Styling | Modern UI library (TBD) | Final selection will be confirmed during UI design. |
 Project Plan Reference: We will be following the feature plan I have previously outlined, which includes these core Epics:


### PR DESCRIPTION
## Summary
- convert the technology stack section into a table for easier scanning
- document Angular 17 as the targeted front-end version and outline the upgrade strategy for future releases

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d00863a68c832b8682cca526384d6b