### PR TITLE
Add documentation for AI agents and reconciliation onboarding

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -1,0 +1,56 @@
+# Universal Reconciliation Platform Knowledge Base
+
+## Mission and Domain Context
+- The platform delivers a configurable reconciliation engine that automates matching, powers break investigation workflows, and enforces strict access controls for financial operations teams.
+- Business value is organised into epics that cover metadata-driven reconciliation setup, LDAP-based security, analyst dashboards, maker-checker governance, reporting, and audit-grade monitoring.
+- Example reconciliations (Cash vs GL and Global Securities Positions) demonstrate both simple and complex onboarding patterns and ship with ETL blueprints, seeded data, and runbook guidance.
+
+## Repository Topology
+- `backend/` — Spring Boot service that exposes reconciliation APIs, executes the matching engine, manages workflow state, emits Excel exports, and bootstraps demo data via startup ETL pipelines.
+- `frontend/` — Angular 17 single-page application with standalone components, a shared state service, and API adapters that orchestrate authentication, reconciliation execution, break management, and exports.
+- `docs/` — Business release narratives, phase-by-phase technical references, developer workflow guidance, and operations runbooks for the seeded demo environments.
+
+## Key Business Capabilities
+1. **Reconciliation configuration** — Define reconciliations by metadata (fields, roles, comparison logic) and trigger matching through manual, scheduled, or event-based execution paths.
+2. **Security & access control** — Delegate authentication to enterprise LDAP, enforce scope-based access via LDAP group membership, and capture maker/checker roles without duplicating entitlements.
+3. **Analyst experience** — Provide a dynamic reconciliation list, run summary analytics, rich break filtering, side-by-side drill-down views, and Excel exports for offline analysis.
+4. **Workflow governance** — Automate break creation, support annotations and attachments, require maker-checker approvals when configured, and track bulk updates.
+5. **Reporting & auditing** — Generate configurable Excel reports and surface activity feeds that log reconciliations, status transitions, comments, exports, and other operational events.
+
+## Backend Architecture Overview
+- **Entry point & configuration** — `UniversalReconciliationPlatformApplication` boots the Spring context, while configuration classes wire JWT security, LDAP integration, and application properties.
+- **REST APIs** — Controllers surface endpoints for authentication, reconciliation discovery and execution, break actions (comments, status updates, bulk operations), exports, and system activity feeds.
+- **Service layer** — `ReconciliationService` enforces access, drives the matching engine, persists runs and breaks, calculates analytics, and records audit events. Supporting services handle break lifecycle updates, Excel generation, LDAP-backed session context, and system activity logging.
+- **Domain model** — Entities capture reconciliation definitions, fields, report templates, runs, break items, comments, source records, and access control entries. Enumerations express field roles, comparison logic, workflow status, trigger types, and audit event categories.
+- **Matching & analytics** — The matching engine executes metadata-driven comparisons across source datasets, produces break candidates, and feeds analytics calculators for dashboard metrics.
+- **Security context** — `UserContext` extracts the authenticated principal and LDAP groups so access enforcement and audit trails are group-aware.
+- **ETL pipelines** — Startup runners execute modular pipelines (simple cash vs GL, complex securities positions) that register metadata, seed access scopes, load source A/B records from CSV, and provision report templates.
+- **Persistence** — Repositories wrap JPA access to reconciliation definitions, runs, breaks, comments, source records, templates, and ACLs, enabling the services to query and persist state consistently.
+
+## Frontend Architecture Overview
+- **Composition** — The standalone `AppComponent` orchestrates login, reconciliation selection, run execution, break triage, exports, and state reset; it delegates to dedicated UI components for reconciliation lists, run summaries, break detail, workflow actions, and system activity.
+- **State management** — `ReconciliationStateService` centralises BehaviourSubject stores for reconciliations, current selection, run detail, break filters, and activity feed; it calls the API, reacts to updates, and synchronises UI selections.
+- **API integration** — `ApiService` wraps REST endpoints for authentication, reconciliation runs, filters, break updates, exports, and activity retrieval, translating UI filters into HTTP parameters.
+- **Workflow UX** — Components emit events for triggering runs, applying filters, adding comments, changing statuses, performing bulk updates, and exporting Excel, while templates render responsive layouts and highlight workflow state.
+- **Session handling** — `SessionService` (injected into the app component) persists login state so authenticated sessions survive refresh and coordinate with the API headers.
+
+## Data & ETL Patterns
+- `SampleEtlRunner` discovers all `EtlPipeline` beans and executes them at startup, ensuring demo reconciliations are seeded automatically.
+- Shared helpers in `AbstractSampleEtlPipeline` build reconciliation definitions, register fields with comparison logic and tolerances, create report templates, assign LDAP-based access scopes, and load CSV data into source repositories.
+- `SimpleCashGlEtlPipeline` and `SecuritiesPositionEtlPipeline` demonstrate how to onboard reconciliations ranging from straightforward cash matching to tolerance-based securities workflows, including maker-checker enablement and rich report configurations.
+
+## Development Workflow & Tooling
+- Install prerequisites (JDK 17+, Maven 3.9+, Node.js 18+) and bootstrap dependencies via Maven and npm.
+- Run the backend with `./mvnw spring-boot:run` and the frontend with `npm start`; the dev server proxies API calls to the backend URL configured in the environment file.
+- Coding standards emphasise constructor injection, immutable DTOs, Angular standalone components, and comprehensive technical documentation updates for each change.
+- Quality gates require `mvn test` with ≥70% coverage, `npm test -- --watch=false --browsers=ChromeHeadless`, and optional linting via `npm run lint` before raising pull requests.
+
+## Operational Notes
+- Demo authentication accepts any credentials and populates sessions with LDAP-style group authorities for makers and checkers.
+- Restarting the backend reruns ETL pipelines to refresh sample data, report templates, and access control entries.
+- Activity feeds, Excel exports, and audit logs provide visibility into reconciliation runs, break actions, and reporting events for support teams.
+
+## Further Reading
+- Business overviews in `docs/business/` explain phased feature delivery and stakeholder value.
+- Line-by-line technical references in `docs/technical/` describe every backend and frontend source file across all phases.
+- `docs/developer-guide.md` and `docs/operations-guide.md` cover day-to-day development, deployment, and troubleshooting practices.

--- a/New Recon.md
+++ b/New Recon.md
@@ -1,0 +1,48 @@
+# Onboarding a New Reconciliation
+
+This runbook explains how to introduce an additional reconciliation definition into the Universal Reconciliation Platform by extending the existing metadata-driven patterns.
+
+## 1. Gather Business Inputs
+- Confirm source systems, key identifiers, comparison fields, tolerances, and display metadata with operations stakeholders.
+- Capture maker/checker requirements, required access scopes (product, sub-product, entity), and reporting expectations (matched/mismatched coverage, highlight rules).
+
+## 2. Model the Metadata
+- Define a unique reconciliation code, name, and description to represent the process in the UI.
+- Classify each field as a key, comparison, display, or product hierarchy attribute, and record its data type and comparison logic (exact, case-insensitive, numeric threshold, date-only, etc.).
+- Decide which fields belong in Excel exports, where highlight rules apply, and how the tabs should appear for matched, mismatched, and missing records.
+
+## 3. Build an ETL Pipeline
+1. Create a new class in `backend/src/main/java/com/universal/reconciliation/etl/` that extends `AbstractSampleEtlPipeline`.
+2. Override `name()` for logging clarity and implement `run()` to:
+   - Skip seeding if the definition already exists.
+   - Construct the reconciliation definition via `definition(...)`, register fields with `field(...)`, and attach report templates using `template(...)` and `column(...)` helpers.
+   - Persist access control entries (`entry(...)`) for each LDAP group, product, sub-product, and entity combination you want to expose.
+   - Load Source A/B records by reading CSV resources through `readCsv(...)` and mapping rows into `SourceRecordA` and `SourceRecordB` entities.
+3. Annotate the class with `@Component` and assign an `@Order` to control load sequencing relative to the existing sample pipelines.
+
+## 4. Supply Data Files
+- Place CSV extracts for Source A and Source B under `backend/src/main/resources/etl/<your-recon>/`.
+- Ensure headers match the field names expected in the mapping logic; reuse helper methods `decimal(...)` and `date(...)` to normalise numeric and date values.
+
+## 5. Register the Pipeline
+- `SampleEtlRunner` automatically executes every `EtlPipeline` bean on startup, so no manual wiring is required once the class is annotated with `@Component`.
+- Restarting the backend will invoke your pipeline and seed the metadata, access control entries, source records, and report templates.
+
+## 6. Expose Access Scopes
+- Update the maker and checker LDAP group names as required when creating `AccessControlEntry` instances in the pipeline.
+- Adjust the product/sub-product/entity values to align with the business hierarchy so frontend filters work out of the box.
+
+## 7. Validate End-to-End
+1. Start the backend and confirm logs show your pipeline executing without errors.
+2. Launch the frontend, authenticate, and verify the new reconciliation appears in the list for authorised groups.
+3. Trigger a run and inspect run analytics, break inventory, filters, break workflow actions, and Excel export output.
+4. Review the system activity feed to confirm run, comment, status, and export events reference the new reconciliation.
+
+## 8. Document the Addition
+- Add a summary of the new reconciliation to `docs/business/` and `docs/technical/` following the phase-based documentation pattern.
+- Record any special operating procedures (file delivery timing, tolerances, escalation paths) in `docs/operations-guide.md` if needed.
+
+## 9. Prepare for Production
+- Swap CSV-based seeding for a production-grade ingestion mechanism (database integration, file transfer, streaming) while retaining the same metadata configuration model.
+- Coordinate with identity management to create or reuse LDAP groups that mirror the maker/checker access matrix defined in the pipeline.
+- Schedule automated reconciliation triggers (cron, API hooks, messaging) to align with upstream data availability once validated.

--- a/docs/feature.md
+++ b/docs/feature.md
@@ -1,0 +1,15 @@
+# Platform Feature Matrix
+
+## Backend Features
+- Spring Boot REST API surface for authentication, reconciliation discovery, run execution, break management, exports, and system activity feeds.
+- Metadata-driven matching engine that enforces access control, persists runs, calculates analytics, and records audit events for every reconciliation execution.
+- Maker-checker aware workflow services supporting comments, status transitions, and bulk updates on breaks.
+- Excel export engine backed by configurable report templates and audit logging for download events.
+- Startup ETL pipelines that register reconciliation definitions, provision LDAP-scoped access control, and load sample source data from CSV into MariaDB tables.
+
+## Frontend Features
+- Angular standalone application with authenticated sessions, reconciliation selection, trigger configuration, and responsive dashboard layout.
+- Shared state service coordinating reconciliation lists, run summaries, break inventories, filters, and system activity streams.
+- UI workflows for adding comments, updating statuses, applying bulk actions, and exporting Excel reports directly from the dashboard.
+- REST client wrappers that translate UI interactions into backend API calls, including filter-aware run retrieval and export downloads.
+- Activity feed and break detail components that present audit trails, side-by-side source data, and workflow context for analysts.


### PR DESCRIPTION
## Summary
- add `AI.md` knowledge base to capture platform architecture, workflows, and operational context
- document backend and frontend feature highlights in `docs/feature.md`
- provide `New Recon.md` runbook describing how to onboard additional reconciliations

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d14067ba74832bbbaf9247cdaf1c02