### PR TITLE
Align example pipelines with latest platform metadata

### DIFF
--- a/examples/admin-configurator/payloads/reconciliation.json
+++ b/examples/admin-configurator/payloads/reconciliation.json
@@ -5,7 +5,7 @@
   "owner": "Custody Operations",
   "makerCheckerEnabled": true,
   "notes": "Authored via admin configurator example",
-  "status": "DRAFT",
+  "status": "PUBLISHED",
   "autoTriggerEnabled": true,
   "autoTriggerCron": "0 2 * * *",
   "autoTriggerTimezone": "UTC",

--- a/examples/cash-vs-gl/README.md
+++ b/examples/cash-vs-gl/README.md
@@ -13,6 +13,10 @@ general ledger agree with balances delivered by the upstream bank feed.
 sources are ingested by the CSV adapter that is configured in the pipeline.
 - **Matching logic:** The reconciliation key is `transactionId` with exact comparisons on amount,
 trade date, and currency plus product/entity classifiers that drive report segmentation.
+- **Automation:** The definition auto-triggers on a weekday 07:00 Eastern cron with a 20 minute
+grace window so the example reflects the platform's scheduling controls.
+- **Notifications:** Maker groups receive ingestion failure alerts while checkers are notified upon
+publish to mirror the activity stream and compliance hooks.
 - **Workflow:** Maker-checker is disabled for brevity, but access control entries still grant maker
 and checker visibility across the demo business units.
 

--- a/examples/cash-vs-gl/scripts/run_e2e.sh
+++ b/examples/cash-vs-gl/scripts/run_e2e.sh
@@ -6,6 +6,6 @@ BACKEND_DIR="$PROJECT_ROOT/backend"
 COMMON_DIR="$PROJECT_ROOT/examples/common"
 EXAMPLE_DIR="$PROJECT_ROOT/examples/cash-vs-gl"
 
-"$BACKEND_DIR/mvnw" -f "$BACKEND_DIR/pom.xml" install -DskipTests -Dspring-boot.repackage.skip=true
-"$BACKEND_DIR/mvnw" -f "$COMMON_DIR/pom.xml" install -DskipTests
-"$BACKEND_DIR/mvnw" -f "$EXAMPLE_DIR/pom.xml" test
+"$BACKEND_DIR/mvnw" -f "$BACKEND_DIR/pom.xml" clean install -DskipTests -Dspring-boot.repackage.skip=true
+"$BACKEND_DIR/mvnw" -f "$COMMON_DIR/pom.xml" clean install -DskipTests
+"$BACKEND_DIR/mvnw" -f "$EXAMPLE_DIR/pom.xml" clean test

--- a/examples/common/src/main/java/com/universal/reconciliation/examples/support/AbstractExampleEtlPipeline.java
+++ b/examples/common/src/main/java/com/universal/reconciliation/examples/support/AbstractExampleEtlPipeline.java
@@ -13,6 +13,7 @@ import com.universal.reconciliation.domain.enums.FieldDataType;
 import com.universal.reconciliation.domain.enums.FieldRole;
 import com.universal.reconciliation.domain.enums.IngestionAdapterType;
 import com.universal.reconciliation.domain.enums.ReportColumnSource;
+import com.universal.reconciliation.domain.enums.ReconciliationLifecycleStatus;
 import com.universal.reconciliation.repository.AccessControlEntryRepository;
 import com.universal.reconciliation.repository.CanonicalFieldRepository;
 import com.universal.reconciliation.repository.ReconciliationDefinitionRepository;
@@ -82,6 +83,11 @@ public abstract class AbstractExampleEtlPipeline {
         definition.setName(name);
         definition.setDescription(description);
         definition.setMakerCheckerEnabled(makerCheckerEnabled);
+        definition.setStatus(ReconciliationLifecycleStatus.PUBLISHED);
+        definition.setAutoTriggerEnabled(false);
+        definition.setAutoTriggerCron(null);
+        definition.setAutoTriggerTimezone(null);
+        definition.setAutoTriggerGraceMinutes(null);
         return definition;
     }
 
@@ -198,6 +204,9 @@ public abstract class AbstractExampleEtlPipeline {
         entry.setProduct(product);
         entry.setSubProduct(subProduct);
         entry.setEntityName(entity);
+        entry.setNotifyOnPublish(false);
+        entry.setNotifyOnIngestionFailure(false);
+        entry.setNotificationChannel(null);
         return entry;
     }
 

--- a/examples/custodian-trade/README.md
+++ b/examples/custodian-trade/README.md
@@ -13,9 +13,13 @@ infrastructure.
   identifies which custodian should have reported each item.
 - **Matching logic:** Trades are keyed by `trade_id` and `source` with tolerance-based comparisons on
   quantity and gross amount so minor rounding differences are tolerated.
+- **Metadata:** Source definitions capture arrival expectations, SLA minutes, and adapter options to
+  demonstrate the platform's richer ingestion metadata model.
 - **Cutoffs and scheduling:** Morning runs are triggered automatically when all files are present,
   while the evening run is forced at 18:00 if a custodian is late. Report jobs run at 15:00, 21:00,
   and 02:00 to cover operational and compliance needs.
+- **Notifications:** Makers receive ingestion failure alerts, checkers receive publish notifications,
+  and operations viewers are copied via the metadata-driven notification channel.
 - **Workflow:** Maker-checker is enabled and access roles are provisioned for makers, checkers, and
   operations viewers across the equities desk.
 

--- a/examples/custodian-trade/scripts/run_e2e.sh
+++ b/examples/custodian-trade/scripts/run_e2e.sh
@@ -6,6 +6,6 @@ BACKEND_DIR="$PROJECT_ROOT/backend"
 COMMON_DIR="$PROJECT_ROOT/examples/common"
 EXAMPLE_DIR="$PROJECT_ROOT/examples/custodian-trade"
 
-"$BACKEND_DIR/mvnw" -f "$BACKEND_DIR/pom.xml" install -DskipTests -Dspring-boot.repackage.skip=true
-"$BACKEND_DIR/mvnw" -f "$COMMON_DIR/pom.xml" install -DskipTests
-"$BACKEND_DIR/mvnw" -f "$EXAMPLE_DIR/pom.xml" test
+"$BACKEND_DIR/mvnw" -f "$BACKEND_DIR/pom.xml" clean install -DskipTests -Dspring-boot.repackage.skip=true
+"$BACKEND_DIR/mvnw" -f "$COMMON_DIR/pom.xml" clean install -DskipTests
+"$BACKEND_DIR/mvnw" -f "$EXAMPLE_DIR/pom.xml" clean test

--- a/examples/securities-position/README.md
+++ b/examples/securities-position/README.md
@@ -14,6 +14,10 @@ self-contained Spring Boot application.
 - **Matching logic:** Positions are keyed by account and ISIN with numeric tolerances applied to
   quantity and market value fields. Currency and valuation date comparisons enforce straight-through
   accuracy, and additional metadata captures custodian and portfolio manager context.
+- **Automation:** The reconciliation auto-triggers on a weekday 18:00 London cron with a 25 minute
+  grace window to showcase the scheduling metadata.
+- **Notifications:** Makers are alerted on ingestion failure while checkers are notified when runs
+  publish so the activity stream reflects real-world governance.
 - **Workflow:** Maker-checker approvals are enabled; access control entries grant makers and checkers
   visibility across the securities desk.
 

--- a/examples/securities-position/scripts/run_e2e.sh
+++ b/examples/securities-position/scripts/run_e2e.sh
@@ -6,6 +6,6 @@ BACKEND_DIR="$PROJECT_ROOT/backend"
 COMMON_DIR="$PROJECT_ROOT/examples/common"
 EXAMPLE_DIR="$PROJECT_ROOT/examples/securities-position"
 
-"$BACKEND_DIR/mvnw" -f "$BACKEND_DIR/pom.xml" install -DskipTests -Dspring-boot.repackage.skip=true
-"$BACKEND_DIR/mvnw" -f "$COMMON_DIR/pom.xml" install -DskipTests
-"$BACKEND_DIR/mvnw" -f "$EXAMPLE_DIR/pom.xml" test
+"$BACKEND_DIR/mvnw" -f "$BACKEND_DIR/pom.xml" clean install -DskipTests -Dspring-boot.repackage.skip=true
+"$BACKEND_DIR/mvnw" -f "$COMMON_DIR/pom.xml" clean install -DskipTests
+"$BACKEND_DIR/mvnw" -f "$EXAMPLE_DIR/pom.xml" clean test


### PR DESCRIPTION
## Summary
- align all standalone example pipelines with current platform metadata (owners, auto trigger schedules, SLAs, notifications)
- update example READMEs to document automation and alert behavior
- make integration harness script mac-compatible and ensure clean builds for each example before running

## Testing
- examples/cash-vs-gl/scripts/run_e2e.sh
- examples/securities-position/scripts/run_e2e.sh
- examples/custodian-trade/scripts/run_e2e.sh
- examples/integration-harness/scripts/run_multi_example_e2e.sh
- examples/admin-configurator/scripts/bootstrap.sh