### PR TITLE
Fix analyst workspace result grid responsiveness and attribute rendering

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@angular/compiler": "^17.2.0",
         "@angular/core": "^17.2.0",
         "@angular/forms": "^17.2.0",
+        "@angular/material": "^17.2.0",
         "@angular/platform-browser": "^17.2.0",
         "@angular/platform-browser-dynamic": "^17.2.0",
         "@angular/router": "^17.2.0",
@@ -532,6 +533,71 @@
         "@angular/common": "17.3.12",
         "@angular/core": "17.3.12",
         "@angular/platform-browser": "17.3.12",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/material": {
+      "version": "17.3.10",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-17.3.10.tgz",
+      "integrity": "sha512-hHMQES0tQPH5JW33W+mpBPuM8ybsloDTqFPuRV8cboDjosAWfJhzAKF3ozICpNlUrs62La/2Wu/756GcQrxebg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/auto-init": "15.0.0-canary.7f224ddd4.0",
+        "@material/banner": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/button": "15.0.0-canary.7f224ddd4.0",
+        "@material/card": "15.0.0-canary.7f224ddd4.0",
+        "@material/checkbox": "15.0.0-canary.7f224ddd4.0",
+        "@material/chips": "15.0.0-canary.7f224ddd4.0",
+        "@material/circular-progress": "15.0.0-canary.7f224ddd4.0",
+        "@material/data-table": "15.0.0-canary.7f224ddd4.0",
+        "@material/density": "15.0.0-canary.7f224ddd4.0",
+        "@material/dialog": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/drawer": "15.0.0-canary.7f224ddd4.0",
+        "@material/elevation": "15.0.0-canary.7f224ddd4.0",
+        "@material/fab": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/floating-label": "15.0.0-canary.7f224ddd4.0",
+        "@material/form-field": "15.0.0-canary.7f224ddd4.0",
+        "@material/icon-button": "15.0.0-canary.7f224ddd4.0",
+        "@material/image-list": "15.0.0-canary.7f224ddd4.0",
+        "@material/layout-grid": "15.0.0-canary.7f224ddd4.0",
+        "@material/line-ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/linear-progress": "15.0.0-canary.7f224ddd4.0",
+        "@material/list": "15.0.0-canary.7f224ddd4.0",
+        "@material/menu": "15.0.0-canary.7f224ddd4.0",
+        "@material/menu-surface": "15.0.0-canary.7f224ddd4.0",
+        "@material/notched-outline": "15.0.0-canary.7f224ddd4.0",
+        "@material/radio": "15.0.0-canary.7f224ddd4.0",
+        "@material/ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/segmented-button": "15.0.0-canary.7f224ddd4.0",
+        "@material/select": "15.0.0-canary.7f224ddd4.0",
+        "@material/shape": "15.0.0-canary.7f224ddd4.0",
+        "@material/slider": "15.0.0-canary.7f224ddd4.0",
+        "@material/snackbar": "15.0.0-canary.7f224ddd4.0",
+        "@material/switch": "15.0.0-canary.7f224ddd4.0",
+        "@material/tab": "15.0.0-canary.7f224ddd4.0",
+        "@material/tab-bar": "15.0.0-canary.7f224ddd4.0",
+        "@material/tab-indicator": "15.0.0-canary.7f224ddd4.0",
+        "@material/tab-scroller": "15.0.0-canary.7f224ddd4.0",
+        "@material/textfield": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/tooltip": "15.0.0-canary.7f224ddd4.0",
+        "@material/top-app-bar": "15.0.0-canary.7f224ddd4.0",
+        "@material/touch-target": "15.0.0-canary.7f224ddd4.0",
+        "@material/typography": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/animations": "^17.0.0 || ^18.0.0",
+        "@angular/cdk": "17.3.10",
+        "@angular/common": "^17.0.0 || ^18.0.0",
+        "@angular/core": "^17.0.0 || ^18.0.0",
+        "@angular/forms": "^17.0.0 || ^18.0.0",
+        "@angular/platform-browser": "^17.0.0 || ^18.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -2915,6 +2981,808 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/@material/animation": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-1GSJaPKef+7HRuV+HusVZHps64cmZuOItDbt40tjJVaikcaZvwmHlcTxRIqzcRoCdt5ZKHh3NoO7GB9Khg4Jnw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/auto-init": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/auto-init/-/auto-init-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-t7ZGpRJ3ec0QDUO0nJu/SMgLW7qcuG2KqIsEYD1Ej8qhI2xpdR2ydSDQOkVEitXmKoGol1oq4nYSBjTlB65GqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/banner": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/banner/-/banner-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-g9wBUZzYBizyBcBQXTIafnRUUPi7efU9gPJfzeGgkynXiccP/vh5XMmH+PBxl5v+4MlP/d4cZ2NUYoAN7UTqSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/button": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/elevation": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/shape": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/tokens": "15.0.0-canary.7f224ddd4.0",
+        "@material/typography": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/base": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/base/-/base-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-I9KQOKXpLfJkP8MqZyr8wZIzdPHrwPjFvGd9zSK91/vPyE4hzHRJc/0njsh9g8Lm9PRYLbifXX+719uTbHxx+A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/button": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/button/-/button-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-BHB7iyHgRVH+JF16+iscR+Qaic+p7LU1FOLgP8KucRlpF9tTwIxQA6mJwGRi5gUtcG+vyCmzVS+hIQ6DqT/7BA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/density": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/elevation": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/focus-ring": "15.0.0-canary.7f224ddd4.0",
+        "@material/ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/shape": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/tokens": "15.0.0-canary.7f224ddd4.0",
+        "@material/touch-target": "15.0.0-canary.7f224ddd4.0",
+        "@material/typography": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/card": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/card/-/card-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-kt7y9/IWOtJTr3Z/AoWJT3ZLN7CLlzXhx2udCLP9ootZU2bfGK0lzNwmo80bv/pJfrY9ihQKCtuGTtNxUy+vIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/elevation": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/shape": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/tokens": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/checkbox": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/checkbox/-/checkbox-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-rURcrL5O1u6hzWR+dNgiQ/n89vk6tdmdP3mZgnxJx61q4I/k1yijKqNJSLrkXH7Rto3bM5NRKMOlgvMvVd7UMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/density": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/focus-ring": "15.0.0-canary.7f224ddd4.0",
+        "@material/ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/touch-target": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/chips": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/chips/-/chips-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-AYAivV3GSk/T/nRIpH27sOHFPaSMrE3L0WYbnb5Wa93FgY8a0fbsFYtSH2QmtwnzXveg+B1zGTt7/xIIcynKdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/checkbox": "15.0.0-canary.7f224ddd4.0",
+        "@material/density": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/elevation": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/focus-ring": "15.0.0-canary.7f224ddd4.0",
+        "@material/ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/shape": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/tokens": "15.0.0-canary.7f224ddd4.0",
+        "@material/touch-target": "15.0.0-canary.7f224ddd4.0",
+        "@material/typography": "15.0.0-canary.7f224ddd4.0",
+        "safevalues": "^0.3.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/circular-progress": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/circular-progress/-/circular-progress-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-DJrqCKb+LuGtjNvKl8XigvyK02y36GRkfhMUYTcJEi3PrOE00bwXtyj7ilhzEVshQiXg6AHGWXtf5UqwNrx3Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/progress-indicator": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/data-table": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/data-table/-/data-table-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-/2WZsuBIq9z9RWYF5Jo6b7P6u0fwit+29/mN7rmAZ6akqUR54nXyNfoSNiyydMkzPlZZsep5KrSHododDhBZbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/checkbox": "15.0.0-canary.7f224ddd4.0",
+        "@material/density": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/elevation": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/icon-button": "15.0.0-canary.7f224ddd4.0",
+        "@material/linear-progress": "15.0.0-canary.7f224ddd4.0",
+        "@material/list": "15.0.0-canary.7f224ddd4.0",
+        "@material/menu": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/select": "15.0.0-canary.7f224ddd4.0",
+        "@material/shape": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/tokens": "15.0.0-canary.7f224ddd4.0",
+        "@material/touch-target": "15.0.0-canary.7f224ddd4.0",
+        "@material/typography": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/density": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/density/-/density-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-o9EXmGKVpiQ6mHhyV3oDDzc78Ow3E7v8dlaOhgaDSXgmqaE8v5sIlLNa/LKSyUga83/fpGk3QViSGXotpQx0jA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/dialog": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/dialog/-/dialog-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-u0XpTlv1JqWC/bQ3DavJ1JguofTelLT2wloj59l3/1b60jv42JQ6Am7jU3I8/SIUB1MKaW7dYocXjDWtWJakLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/button": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/elevation": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/icon-button": "15.0.0-canary.7f224ddd4.0",
+        "@material/ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/shape": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/tokens": "15.0.0-canary.7f224ddd4.0",
+        "@material/touch-target": "15.0.0-canary.7f224ddd4.0",
+        "@material/typography": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/dom": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-mQ1HT186GPQSkRg5S18i70typ5ZytfjL09R0gJ2Qg5/G+MLCGi7TAjZZSH65tuD/QGOjel4rDdWOTmYbPYV6HA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/drawer": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/drawer/-/drawer-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-qyO0W0KBftfH8dlLR0gVAgv7ZHNvU8ae11Ao6zJif/YxcvK4+gph1z8AO4H410YmC2kZiwpSKyxM1iQCCzbb4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/elevation": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/list": "15.0.0-canary.7f224ddd4.0",
+        "@material/ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/shape": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/typography": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/elevation": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-tV6s4/pUBECedaI36Yj18KmRCk1vfue/JP/5yYRlFNnLMRVISePbZaKkn/BHXVf+26I3W879+XqIGlDVdmOoMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/fab": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/fab/-/fab-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-4h76QrzfZTcPdd+awDPZ4Q0YdSqsXQnS540TPtyXUJ/5G99V6VwGpjMPIxAsW0y+pmI9UkLL/srrMaJec+7r4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/elevation": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/focus-ring": "15.0.0-canary.7f224ddd4.0",
+        "@material/ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/shape": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/tokens": "15.0.0-canary.7f224ddd4.0",
+        "@material/touch-target": "15.0.0-canary.7f224ddd4.0",
+        "@material/typography": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/feature-targeting": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-SAjtxYh6YlKZriU83diDEQ7jNSP2MnxKsER0TvFeyG1vX/DWsUyYDOIJTOEa9K1N+fgJEBkNK8hY55QhQaspew==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/floating-label": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/floating-label/-/floating-label-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-0KMo5ijjYaEHPiZ2pCVIcbaTS2LycvH9zEhEMKwPPGssBCX7iz5ffYQFk7e5yrQand1r3jnQQgYfHAwtykArnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/typography": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/focus-ring": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/focus-ring/-/focus-ring-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-Jmg1nltq4J6S6A10EGMZnvufrvU3YTi+8R8ZD9lkSbun0Fm2TVdICQt/Auyi6An9zP66oQN6c31eqO6KfIPsDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0"
+      }
+    },
+    "node_modules/@material/form-field": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/form-field/-/form-field-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-fEPWgDQEPJ6WF7hNnIStxucHR9LE4DoDSMqCsGWS2Yu+NLZYLuCEecgR0UqQsl1EQdNRaFh8VH93KuxGd2hiPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/typography": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/icon-button": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/icon-button/-/icon-button-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-DcK7IL4ICY/DW+48YQZZs9g0U1kRaW0Wb0BxhvppDMYziHo/CTpFdle4gjyuTyRxPOdHQz5a97ru48Z9O4muTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/density": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/elevation": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/focus-ring": "15.0.0-canary.7f224ddd4.0",
+        "@material/ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/touch-target": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/image-list": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/image-list/-/image-list-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-voMjG2p80XbjL1B2lmF65zO5gEgJOVKClLdqh4wbYzYfwY/SR9c8eLvlYG7DLdFaFBl/7gGxD8TvvZ329HUFPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/shape": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/typography": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/layout-grid": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/layout-grid/-/layout-grid-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-veDABLxMn2RmvfnUO2RUmC1OFfWr4cU+MrxKPoDD2hl3l3eDYv5fxws6r5T1JoSyXoaN+oEZpheS0+M9Ure8Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/line-ripple": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/line-ripple/-/line-ripple-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-f60hVJhIU6I3/17Tqqzch1emUKEcfVVgHVqADbU14JD+oEIz429ZX9ksZ3VChoU3+eejFl+jVdZMLE/LrAuwpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/linear-progress": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/linear-progress/-/linear-progress-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-pRDEwPQielDiC9Sc5XhCXrGxP8wWOnAO8sQlMebfBYHYqy5hhiIzibezS8CSaW4MFQFyXmCmpmqWlbqGYRmiyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/progress-indicator": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/list": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/list/-/list-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-Is0NV91sJlXF5pOebYAtWLF4wU2MJDbYqztML/zQNENkQxDOvEXu3nWNb3YScMIYJJXvARO0Liur5K4yPagS1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/density": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/shape": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/tokens": "15.0.0-canary.7f224ddd4.0",
+        "@material/typography": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/menu": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/menu/-/menu-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-D11QU1dXqLbh5X1zKlEhS3QWh0b5BPNXlafc5MXfkdJHhOiieb7LC9hMJhbrHtj24FadJ7evaFW/T2ugJbJNnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/elevation": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/list": "15.0.0-canary.7f224ddd4.0",
+        "@material/menu-surface": "15.0.0-canary.7f224ddd4.0",
+        "@material/ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/shape": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/tokens": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/menu-surface": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/menu-surface/-/menu-surface-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-7RZHvw0gbwppaAJ/Oh5SWmfAKJ62aw1IMB3+3MRwsb5PLoV666wInYa+zJfE4i7qBeOn904xqT2Nko5hY0ssrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/elevation": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/shape": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/notched-outline": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/notched-outline/-/notched-outline-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-Yg2usuKB2DKlKIBISbie9BFsOVuffF71xjbxPbybvqemxqUBd+bD5/t6H1fLE+F8/NCu5JMigho4ewUU+0RCiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/floating-label": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/shape": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/progress-indicator": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/progress-indicator/-/progress-indicator-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-UPbDjE5CqT+SqTs0mNFG6uFEw7wBlgYmh+noSkQ6ty/EURm8lF125dmi4dv4kW0+octonMXqkGtAoZwLIHKf/w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/radio": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/radio/-/radio-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-wR1X0Sr0KmQLu6+YOFKAI84G3L6psqd7Kys5kfb8WKBM36zxO5HQXC5nJm/Y0rdn22ixzsIz2GBo0MNU4V4k1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/density": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/focus-ring": "15.0.0-canary.7f224ddd4.0",
+        "@material/ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/touch-target": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/ripple": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-JqOsWM1f4aGdotP0rh1vZlPZTg6lZgh39FIYHFMfOwfhR+LAikUJ+37ciqZuewgzXB6iiRO6a8aUH6HR5SJYPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/rtl": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-UVf14qAtmPiaaZjuJtmN36HETyoKWmsZM/qn1L5ciR2URb8O035dFWnz4ZWFMmAYBno/L7JiZaCkPurv2ZNrGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/segmented-button": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/segmented-button/-/segmented-button-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-LCnVRUSAhELTKI/9hSvyvIvQIpPpqF29BV+O9yM4WoNNmNWqTulvuiv7grHZl6Z+kJuxSg4BGbsPxxb9dXozPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/elevation": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/touch-target": "15.0.0-canary.7f224ddd4.0",
+        "@material/typography": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/select": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/select/-/select-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-WioZtQEXRpglum0cMSzSqocnhsGRr+ZIhvKb3FlaNrTaK8H3Y4QA7rVjv3emRtrLOOjaT6/RiIaUMTo9AGzWQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/density": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/elevation": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/floating-label": "15.0.0-canary.7f224ddd4.0",
+        "@material/line-ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/list": "15.0.0-canary.7f224ddd4.0",
+        "@material/menu": "15.0.0-canary.7f224ddd4.0",
+        "@material/menu-surface": "15.0.0-canary.7f224ddd4.0",
+        "@material/notched-outline": "15.0.0-canary.7f224ddd4.0",
+        "@material/ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/shape": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/tokens": "15.0.0-canary.7f224ddd4.0",
+        "@material/typography": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/shape": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/shape/-/shape-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-8z8l1W3+cymObunJoRhwFPKZ+FyECfJ4MJykNiaZq7XJFZkV6xNmqAVrrbQj93FtLsECn9g4PjjIomguVn/OEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/slider": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/slider/-/slider-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-QU/WSaSWlLKQRqOhJrPgm29wqvvzRusMqwAcrCh1JTrCl+xwJ43q5WLDfjYhubeKtrEEgGu9tekkAiYfMG7EBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/elevation": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/tokens": "15.0.0-canary.7f224ddd4.0",
+        "@material/typography": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/snackbar": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/snackbar/-/snackbar-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-sm7EbVKddaXpT/aXAYBdPoN0k8yeg9+dprgBUkrdqGzWJAeCkxb4fv2B3He88YiCtvkTz2KLY4CThPQBSEsMFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/button": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/elevation": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/icon-button": "15.0.0-canary.7f224ddd4.0",
+        "@material/ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/shape": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/tokens": "15.0.0-canary.7f224ddd4.0",
+        "@material/typography": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/switch": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/switch/-/switch-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-lEDJfRvkVyyeHWIBfoxYjJVl+WlEAE2kZ/+6OqB1FW0OV8ftTODZGhHRSzjVBA1/p4FPuhAtKtoK9jTpa4AZjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/density": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/elevation": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/focus-ring": "15.0.0-canary.7f224ddd4.0",
+        "@material/ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/shape": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/tokens": "15.0.0-canary.7f224ddd4.0",
+        "safevalues": "^0.3.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/tab/-/tab-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-E1xGACImyCLurhnizyOTCgOiVezce4HlBFAI6YhJo/AyVwjN2Dtas4ZLQMvvWWqpyhITNkeYdOchwCC1mrz3AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/elevation": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/focus-ring": "15.0.0-canary.7f224ddd4.0",
+        "@material/ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/tab-indicator": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/tokens": "15.0.0-canary.7f224ddd4.0",
+        "@material/typography": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab-bar": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-bar/-/tab-bar-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-p1Asb2NzrcECvAQU3b2SYrpyJGyJLQWR+nXTYzDKE8WOpLIRCXap2audNqD7fvN/A20UJ1J8U01ptrvCkwJ4eA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/density": "15.0.0-canary.7f224ddd4.0",
+        "@material/elevation": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/tab": "15.0.0-canary.7f224ddd4.0",
+        "@material/tab-indicator": "15.0.0-canary.7f224ddd4.0",
+        "@material/tab-scroller": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/tokens": "15.0.0-canary.7f224ddd4.0",
+        "@material/typography": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab-indicator": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-indicator/-/tab-indicator-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-h9Td3MPqbs33spcPS7ecByRHraYgU4tNCZpZzZXw31RypjKvISDv/PS5wcA4RmWqNGih78T7xg4QIGsZg4Pk4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab-scroller": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-scroller/-/tab-scroller-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-LFeYNjQpdXecwECd8UaqHYbhscDCwhGln5Yh+3ctvcEgvmDPNjhKn/DL3sWprWvG8NAhP6sHMrsGhQFVdCWtTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/tab": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/textfield": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/textfield/-/textfield-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-AExmFvgE5nNF0UA4l2cSzPghtxSUQeeoyRjFLHLy+oAaE4eKZFrSy0zEpqPeWPQpEMDZk+6Y+6T3cOFYBeSvsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/density": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/floating-label": "15.0.0-canary.7f224ddd4.0",
+        "@material/line-ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/notched-outline": "15.0.0-canary.7f224ddd4.0",
+        "@material/ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/shape": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/tokens": "15.0.0-canary.7f224ddd4.0",
+        "@material/typography": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/theme": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-hs45hJoE9yVnoVOcsN1jklyOa51U4lzWsEnQEuJTPOk2+0HqCQ0yv/q0InpSnm2i69fNSyZC60+8HADZGF8ugQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tokens": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/tokens/-/tokens-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-r9TDoicmcT7FhUXC4eYMFnt9TZsz0G8T3wXvkKncLppYvZ517gPyD/1+yhuGfGOxAzxTrM66S/oEc1fFE2q4hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/elevation": "15.0.0-canary.7f224ddd4.0"
+      }
+    },
+    "node_modules/@material/tooltip": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/tooltip/-/tooltip-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-8qNk3pmPLTnam3XYC1sZuplQXW9xLn4Z4MI3D+U17Q7pfNZfoOugGr+d2cLA9yWAEjVJYB0mj8Yu86+udo4N9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/button": "15.0.0-canary.7f224ddd4.0",
+        "@material/dom": "15.0.0-canary.7f224ddd4.0",
+        "@material/elevation": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/shape": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/tokens": "15.0.0-canary.7f224ddd4.0",
+        "@material/typography": "15.0.0-canary.7f224ddd4.0",
+        "safevalues": "^0.3.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/top-app-bar": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/top-app-bar/-/top-app-bar-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-SARR5/ClYT4CLe9qAXakbr0i0cMY0V3V4pe3ElIJPfL2Z2c4wGR1mTR8m2LxU1MfGKK8aRoUdtfKaxWejp+eNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.7f224ddd4.0",
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/elevation": "15.0.0-canary.7f224ddd4.0",
+        "@material/ripple": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/shape": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/typography": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/touch-target": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/touch-target/-/touch-target-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-BJo/wFKHPYLGsRaIpd7vsQwKr02LtO2e89Psv0on/p0OephlNIgeB9dD9W+bQmaeZsZ6liKSKRl6wJWDiK71PA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.7f224ddd4.0",
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/rtl": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/typography": {
+      "version": "15.0.0-canary.7f224ddd4.0",
+      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-15.0.0-canary.7f224ddd4.0.tgz",
+      "integrity": "sha512-kBaZeCGD50iq1DeRRH5OM5Jl7Gdk+/NOfKArkY4ksBZvJiStJ7ACAhpvb8MEGm4s3jvDInQFLsDq3hL+SA79sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.7f224ddd4.0",
+        "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@ngtools/webpack": {
@@ -10762,6 +11630,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/safevalues": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/safevalues/-/safevalues-0.3.4.tgz",
+      "integrity": "sha512-LRneZZRXNgjzwG4bDQdOTSbze3fHm1EAKN/8bePxnlEZiBmkYEDggaHbuvHI9/hoqHbGfsEA7tWS9GhYHZBBsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/sass": {
       "version": "1.71.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@angular/compiler": "^17.2.0",
     "@angular/core": "^17.2.0",
     "@angular/forms": "^17.2.0",
+    "@angular/material": "^17.2.0",
     "@angular/platform-browser": "^17.2.0",
     "@angular/platform-browser-dynamic": "^17.2.0",
     "@angular/router": "^17.2.0",

--- a/frontend/src/app/components/analyst-workspace/analyst-workspace.component.css
+++ b/frontend/src/app/components/analyst-workspace/analyst-workspace.component.css
@@ -1,16 +1,23 @@
 .workspace {
   display: grid;
-  grid-template-columns: 320px 1fr 360px;
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr) minmax(280px, 360px);
   gap: 1.5rem;
   padding: 1.5rem;
   min-height: calc(100vh - 3rem);
   box-sizing: border-box;
+  max-width: 100%;
 }
 
 .sidebar {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+}
+
+.sidebar,
+.main,
+.detail-panel {
+  min-width: 0;
 }
 
 .saved-views {
@@ -197,6 +204,47 @@
 .grid-section {
   flex: 1;
   min-height: 420px;
+}
+
+@media (max-width: 1440px) {
+  .workspace {
+    grid-template-columns: minmax(240px, 300px) minmax(0, 1fr) minmax(240px, 320px);
+  }
+}
+
+@media (max-width: 1200px) {
+  .workspace {
+    grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+  }
+
+  .detail-panel {
+    grid-column: span 2;
+  }
+}
+
+@media (max-width: 992px) {
+  .workspace {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .sidebar,
+  .main,
+  .detail-panel {
+    grid-column: 1 / -1;
+  }
+
+  .detail-panel {
+    order: 3;
+  }
+
+  .main {
+    order: 2;
+  }
+
+  .sidebar {
+    order: 1;
+  }
 }
 
 .bulk-actions {

--- a/frontend/src/app/components/analyst-workspace/analyst-workspace.component.css
+++ b/frontend/src/app/components/analyst-workspace/analyst-workspace.component.css
@@ -214,11 +214,14 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .grid-section urp-result-grid {
   flex: 1;
   min-height: 0;
+  min-width: 0;
 }
 
 .result-layout .activity {

--- a/frontend/src/app/components/analyst-workspace/analyst-workspace.component.css
+++ b/frontend/src/app/components/analyst-workspace/analyst-workspace.component.css
@@ -248,14 +248,6 @@
   display: block;
 }
 
-@media (min-width: 1440px) {
-  .result-layout {
-    grid-template-columns: minmax(0, 2.25fr) minmax(260px, 1fr);
-    grid-template-rows: minmax(0, 1fr);
-    align-items: stretch;
-  }
-}
-
 @media (max-width: 1440px) {
   .workspace {
     grid-template-columns: minmax(240px, 300px) minmax(0, 1fr) minmax(240px, 320px);

--- a/frontend/src/app/components/analyst-workspace/analyst-workspace.component.css
+++ b/frontend/src/app/components/analyst-workspace/analyst-workspace.component.css
@@ -201,9 +201,59 @@
   gap: 0.75rem;
 }
 
+.result-layout {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: minmax(0, 1fr) auto;
+  gap: 1.5rem;
+  min-height: 0;
+}
+
 .grid-section {
   flex: 1;
-  min-height: 420px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.grid-section urp-result-grid {
+  flex: 1;
+  min-height: 0;
+}
+
+.result-layout .activity {
+  align-self: stretch;
+  min-height: 0;
+}
+
+.detail-panel {
+  background: #fff;
+  border: 1px solid #e1e1e1;
+  border-radius: 8px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.detail-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+  margin-right: -0.5rem;
+}
+
+.detail-scroll urp-break-detail {
+  display: block;
+}
+
+@media (min-width: 1440px) {
+  .result-layout {
+    grid-template-columns: minmax(0, 2.25fr) minmax(260px, 1fr);
+    grid-template-rows: minmax(0, 1fr);
+    align-items: stretch;
+  }
 }
 
 @media (max-width: 1440px) {
@@ -325,15 +375,6 @@
   border: 1px solid #e1e1e1;
   border-radius: 8px;
   padding: 1rem;
-}
-
-.detail-panel {
-  background: #fff;
-  border: 1px solid #e1e1e1;
-  border-radius: 8px;
-  padding: 1rem;
-  display: flex;
-  flex-direction: column;
 }
 
 @media (max-width: 1440px) {

--- a/frontend/src/app/components/analyst-workspace/analyst-workspace.component.html
+++ b/frontend/src/app/components/analyst-workspace/analyst-workspace.component.html
@@ -171,23 +171,28 @@
       </div>
     </section>
 
-    <section class="grid-section" *ngIf="isActiveTab('runs')">
-      <ng-container *ngIf="rows$ | async as rows">
-        <ng-container *ngIf="columns$ | async as columns">
-          <urp-result-grid
-            [rows]="rows"
-            [columns]="columns"
-            [loading]="loading$ | async"
-            [total]="total$ | async"
-            [selectedRowId]="selectedRow?.breakId || null"
-            [selectedBreakIds]="selectedBreakIds"
-            (selectRow)="handleRowSelect($event)"
-            (requestMore)="loadMore()"
-            (selectionChange)="handleSelectionChange($event)"
-            (selectFiltered)="selectFiltered()"
-          ></urp-result-grid>
+    <section class="result-layout" *ngIf="isActiveTab('runs')">
+      <section class="grid-section">
+        <ng-container *ngIf="rows$ | async as rows">
+          <ng-container *ngIf="columns$ | async as columns">
+            <urp-result-grid
+              [rows]="rows"
+              [columns]="columns"
+              [loading]="loading$ | async"
+              [total]="total$ | async"
+              [selectedRowId]="selectedRow?.breakId || null"
+              [selectedBreakIds]="selectedBreakIds"
+              (selectRow)="handleRowSelect($event)"
+              (requestMore)="loadMore()"
+              (selectionChange)="handleSelectionChange($event)"
+              (selectFiltered)="selectFiltered()"
+            ></urp-result-grid>
+          </ng-container>
         </ng-container>
-      </ng-container>
+      </section>
+      <section class="activity" *ngIf="activity$ | async as activity">
+        <urp-system-activity [entries]="activity"></urp-system-activity>
+      </section>
     </section>
 
     <section class="bulk-actions" *ngIf="isActiveTab('runs') && selectedBreakIds.length > 0">
@@ -275,17 +280,19 @@
       </table>
     </section>
 
-    <section class="activity" *ngIf="activity$ | async as activity">
+    <section class="activity" *ngIf="!isActiveTab('runs') && activity$ | async as activity">
       <urp-system-activity [entries]="activity"></urp-system-activity>
     </section>
   </main>
 
   <aside class="detail-panel" *ngIf="isActiveTab('runs') || isActiveTab('breaks')">
+    <div class="detail-scroll">
       <urp-break-detail
         [breakItem]="selectedBreak$ | async"
         [workflowSummary]="workflowSummary$ | async"
         (addComment)="state.addComment($event.breakId, $event.comment, $event.action)"
         (updateStatus)="state.updateStatus($event.breakId, { status: $event.status, comment: $event.comment })"
       ></urp-break-detail>
+    </div>
   </aside>
 </div>

--- a/frontend/src/app/components/break-detail/break-detail.component.css
+++ b/frontend/src/app/components/break-detail/break-detail.component.css
@@ -1,53 +1,195 @@
 :host {
-  display: block;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  max-width: 100%;
 }
 
 .break-detail {
-  margin-top: 1.5rem;
-  border-top: 1px solid #e2e8f0;
-  padding-top: 1.5rem;
-}
-
-.break-meta {
+  flex: 1;
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
-  font-size: 0.9rem;
-  color: #475569;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding-bottom: 1rem;
+  min-height: 0;
+  color: #0f172a;
 }
 
-.meta-chip {
+.detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.title-group h3 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: #1e293b;
+}
+
+.title-group .detected {
+  margin: 0.35rem 0 0;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.status-group {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0.5rem;
+}
+
+.status-chip,
+.type-chip {
+  display: inline-flex;
+  align-items: center;
   padding: 0.35rem 0.75rem;
-  border-radius: 9999px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.01em;
+}
+
+.status-chip {
+  background: #e2e8f0;
+  color: #0f172a;
+  border: 1px solid #cbd5f5;
+}
+
+.status-chip.status-open,
+.status-chip.status-pending,
+.status-chip.status-pendingapproval {
+  background: #fef3c7;
+  color: #92400e;
+  border-color: #fcd34d;
+}
+
+.status-chip.status-closed {
+  background: #dcfce7;
+  color: #166534;
+  border-color: #bbf7d0;
+}
+
+.status-chip.status-rejected {
+  background: #fee2e2;
+  color: #b91c1c;
+  border-color: #fecaca;
+}
+
+.type-chip {
   background: #eef2ff;
+  color: #3730a3;
   border: 1px solid #c7d2fe;
 }
 
-.meta-chip strong {
-  margin-right: 0.25rem;
+.workflow-summary {
+  background: #f8fafc;
+  border-left: 4px solid #2563eb;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  color: #334155;
+  font-size: 0.95rem;
+}
+
+.section-card {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 1rem 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.section-card h4 {
+  margin: 0;
+  font-size: 1rem;
+  color: #0f172a;
+}
+
+.meta-section {
+  gap: 1rem;
+}
+
+.meta-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.85rem;
+}
+
+.meta-item {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.meta-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: #64748b;
+  letter-spacing: 0.04em;
+}
+
+.meta-value {
+  font-size: 0.95rem;
+  color: #1f2937;
+  word-break: break-word;
+}
+
+.source-comparison {
+  gap: 1rem;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.missing-sources {
+  margin: 0;
+  color: #b45309;
+  font-size: 0.9rem;
+}
+
+.source-table-wrapper {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  overflow-x: auto;
+  background: #fff;
 }
 
 .source-table {
   width: 100%;
+  min-width: 520px;
   border-collapse: collapse;
-  margin-bottom: 1rem;
 }
 
 .source-table thead th {
   background: #f1f5f9;
   font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
 }
 
 .source-table th,
 .source-table td {
-  padding: 0.6rem;
+  padding: 0.65rem 0.75rem;
   border-bottom: 1px solid #e2e8f0;
   text-align: left;
   font-size: 0.9rem;
+  color: #1e293b;
 }
 
 .source-table td.different {
@@ -55,35 +197,49 @@
   font-weight: 600;
 }
 
-.missing-sources {
-  margin-bottom: 0.75rem;
-  color: #b45309;
-  font-size: 0.9rem;
-}
-
 .empty-source {
-  padding: 0.75rem;
+  margin: 0;
+  padding: 0.9rem 1rem;
   background: #f8fafc;
-  border-radius: 6px;
+  border-radius: 8px;
   color: #64748b;
 }
 
+.workflow-history ul,
 .commentary ul {
   list-style: none;
   padding: 0;
-  margin: 1rem 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
+.workflow-history li,
 .commentary li {
-  border-left: 3px solid #3b82f6;
-  margin-bottom: 0.75rem;
+  border-left: 3px solid #2563eb;
   padding-left: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
+.workflow-history .timestamp,
 .commentary .timestamp {
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   color: #64748b;
-  margin-right: 0.5rem;
+}
+
+.workflow-history .role {
+  align-self: flex-start;
+  margin-left: 0;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  color: #0f172a;
+  background: #e0f2fe;
+  border-radius: 999px;
+  padding: 0.1rem 0.5rem;
+  letter-spacing: 0.05em;
 }
 
 .comment-form {
@@ -96,50 +252,11 @@
   resize: vertical;
 }
 
-.workflow-history {
-  margin: 1.5rem 0;
-}
-
-.workflow-history ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.workflow-history li {
-  border-left: 3px solid #0f172a;
-  padding-left: 0.75rem;
-  margin-bottom: 0.75rem;
-}
-
-.workflow-history .role {
-  margin-left: 0.5rem;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  color: #0f172a;
-  background: #e0f2fe;
-  border-radius: 999px;
-  padding: 0.1rem 0.5rem;
-}
-
 .status-buttons {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  margin-top: 1rem;
-}
-
-.status-buttons button {
-  padding: 0.5rem 0.9rem;
-  border: none;
-  background: #2563eb;
-  color: #fff;
-  border-radius: 4px;
-  cursor: pointer;
-}
-
-.status-buttons button:hover {
-  background: #1d4ed8;
+  margin-top: 0.75rem;
 }
 
 .workflow-actions textarea {
@@ -149,6 +266,7 @@
   border-radius: 6px;
   border: 1px solid #cbd5f5;
   padding: 0.6rem;
+  font-size: 0.95rem;
 }
 
 .workflow-actions .hint {
@@ -162,7 +280,7 @@
 }
 
 .no-actions {
-  margin-top: 0.75rem;
+  margin: 0.5rem 0 0;
   color: #64748b;
   font-style: italic;
 }
@@ -170,4 +288,19 @@
 .empty-state {
   color: #475569;
   font-style: italic;
+}
+
+@media (max-width: 768px) {
+  .detail-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .status-group {
+    align-self: flex-start;
+  }
+
+  .source-table {
+    min-width: 420px;
+  }
 }

--- a/frontend/src/app/components/break-detail/break-detail.component.css
+++ b/frontend/src/app/components/break-detail/break-detail.component.css
@@ -190,6 +190,8 @@
   text-align: left;
   font-size: 0.9rem;
   color: #1e293b;
+  word-break: break-word;
+  white-space: normal;
 }
 
 .source-table td.different {

--- a/frontend/src/app/components/break-detail/break-detail.component.html
+++ b/frontend/src/app/components/break-detail/break-detail.component.html
@@ -1,53 +1,78 @@
 <section class="break-detail" *ngIf="breakItem as active; else noBreak">
-  <h3>Break {{ active.id }}</h3>
+  <header class="detail-header">
+    <div class="title-group">
+      <h3>Break {{ active.id }}</h3>
+      <p class="detected">Detected {{ active.detectedAt | date: 'short' }}</p>
+    </div>
+    <div class="status-group">
+      <span class="status-chip status-{{ active.status | lowercase }}">{{ active.status }}</span>
+      <span class="type-chip">{{ active.breakType }}</span>
+    </div>
+  </header>
+
   <div class="workflow-summary" *ngIf="workflowSummary">
     {{ workflowSummary }}
   </div>
-  <div class="break-meta">
-    <span class="meta-chip" *ngFor="let entry of classificationEntries">
-      <strong>{{ formatClassificationKey(entry.key) }}:</strong> {{ entry.value || '—' }}
-    </span>
-    <span class="meta-chip" *ngIf="classificationEntries.length === 0">
-      <strong>Classifications:</strong> Not available
-    </span>
-    <span class="meta-chip"><strong>Break type:</strong> {{ active.breakType }}</span>
-    <span class="meta-chip"><strong>Status:</strong> {{ active.status }}</span>
-    <span class="meta-chip"><strong>Detected:</strong> {{ active.detectedAt | date: 'short' }}</span>
-    <span class="meta-chip" *ngIf="active.submittedByDn">
-      <strong>Submitted by:</strong> {{ active.submittedByDn }}
-      <ng-container *ngIf="active.submittedAt"> on {{ active.submittedAt | date: 'short' }}</ng-container>
-      <ng-container *ngIf="active.submittedByGroup"> via {{ active.submittedByGroup }}</ng-container>
-    </span>
-  </div>
 
-  <p class="missing-sources" *ngIf="active.missingSources?.length">
-    Missing data from: {{ active.missingSources.join(', ') }}
-  </p>
+  <section class="section-card meta-section">
+    <h4>Classifications & details</h4>
+    <div class="meta-grid">
+      <div class="meta-item" *ngFor="let entry of classificationEntries">
+        <span class="meta-label">{{ formatClassificationKey(entry.key) }}</span>
+        <span class="meta-value">{{ entry.value || '—' }}</span>
+      </div>
+      <div class="meta-item" *ngIf="classificationEntries.length === 0">
+        <span class="meta-label">Classifications</span>
+        <span class="meta-value">Not available</span>
+      </div>
+      <div class="meta-item">
+        <span class="meta-label">Submitted by</span>
+        <span class="meta-value">
+          <ng-container *ngIf="active.submittedByDn; else notSubmitted">
+            {{ active.submittedByDn }}
+            <ng-container *ngIf="active.submittedAt"> on {{ active.submittedAt | date: 'short' }}</ng-container>
+            <ng-container *ngIf="active.submittedByGroup"> via {{ active.submittedByGroup }}</ng-container>
+          </ng-container>
+          <ng-template #notSubmitted>—</ng-template>
+        </span>
+      </div>
+    </div>
+  </section>
 
-  <table class="source-table" *ngIf="fieldKeys.length > 0 && sourceKeys.length > 0; else noFields">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th *ngFor="let source of sourceKeys">{{ formatSourceLabel(source) }}</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr *ngFor="let key of fieldKeys">
-        <td>{{ key }}</td>
-        <td
-          *ngFor="let source of sourceKeys"
-          [class.different]="isDifferent(key)"
-        >
-          {{ displayValue(valueFor(source, key)) }}
-        </td>
-      </tr>
-    </tbody>
-  </table>
+  <section class="section-card source-comparison">
+    <div class="section-header">
+      <h4>Source comparison</h4>
+      <p class="missing-sources" *ngIf="active.missingSources?.length">
+        Missing data from: {{ active.missingSources.join(', ') }}
+      </p>
+    </div>
+    <div class="source-table-wrapper" *ngIf="fieldKeys.length > 0 && sourceKeys.length > 0; else noFields">
+      <table class="source-table">
+        <thead>
+          <tr>
+            <th>Field</th>
+            <th *ngFor="let source of sourceKeys">{{ formatSourceLabel(source) }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let key of fieldKeys">
+            <td>{{ key }}</td>
+            <td
+              *ngFor="let source of sourceKeys"
+              [class.different]="isDifferent(key)"
+            >
+              {{ displayValue(valueFor(source, key)) }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
   <ng-template #noFields>
     <p class="empty-source">No field level detail available for the selected break.</p>
   </ng-template>
 
-  <section class="workflow-history">
+  <section class="workflow-history section-card">
     <h4>Workflow history</h4>
     <ul>
       <li *ngFor="let entry of active.history">
@@ -62,7 +87,7 @@
     </ul>
   </section>
 
-  <section class="commentary">
+  <section class="commentary section-card">
     <h4>Commentary</h4>
     <ul>
       <li *ngFor="let comment of active.comments">
@@ -87,7 +112,7 @@
     <p class="no-actions" *ngIf="!canComment">You do not have permission to add comments on this break.</p>
   </section>
 
-  <section class="workflow-actions" *ngIf="statusOptions.length > 0">
+  <section class="workflow-actions section-card" *ngIf="statusOptions.length > 0">
     <h4>Maker-checker actions</h4>
     <p class="hint">Provide context for your action. Approvals and rejections require a comment.</p>
     <textarea

--- a/frontend/src/app/components/result-grid/result-grid.component.css
+++ b/frontend/src/app/components/result-grid/result-grid.component.css
@@ -153,12 +153,13 @@
   align-self: center;
 }
 
+
 .table-container {
   position: relative;
   flex: 1;
   display: flex;
   flex-direction: column;
-  padding: 0 1rem 1rem;
+  padding: 0 1rem 0.5rem;
   overflow: hidden;
   width: 100%;
   min-width: 0;
@@ -335,9 +336,39 @@
   font-style: italic;
 }
 
-mat-paginator {
+.paginator-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
   border-top: 1px solid #e2e8f0;
-  padding: 0.25rem 0.5rem;
+  background: #fff;
+}
+
+.page-size-field {
+  width: 160px;
+}
+
+.page-size-field .mat-mdc-form-field-subscript-wrapper {
+  display: none;
+}
+
+mat-paginator {
+  flex: 1;
+  border-top: none;
+  padding: 0;
+  min-width: 0;
+}
+
+@media (max-width: 600px) {
+  .page-size-field {
+    width: 100%;
+  }
+
+  .paginator-row {
+    justify-content: space-between;
+  }
 }
 
 @media (max-width: 960px) {

--- a/frontend/src/app/components/result-grid/result-grid.component.css
+++ b/frontend/src/app/components/result-grid/result-grid.component.css
@@ -1,120 +1,207 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
 .result-grid {
   display: flex;
   flex-direction: column;
-  border: 1px solid #dcdcdc;
-  border-radius: 6px;
-  overflow: hidden;
-  background: #fff;
   height: 100%;
+  background: #fff;
+  border: 1px solid #dfe3eb;
+  border-radius: 12px;
+  overflow: hidden;
 }
 
 .grid-toolbar {
   display: flex;
-  justify-content: space-between;
+  flex-wrap: wrap;
   align-items: center;
-  padding: 0.5rem 1rem;
-  border-bottom: 1px solid #e6e6e6;
-  background: #fafafa;
-  gap: 1rem;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: #f8fafc;
+  border-bottom: 1px solid #e2e8f0;
 }
 
-.grid-toolbar button {
-  margin-right: 0.5rem;
-}
-
-.table-wrapper {
-  flex: 1;
+.selection {
   display: flex;
-  flex-direction: column;
-  min-width: 0;
-  max-width: 100%;
-}
-
-.table-content {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow-x: auto;
-  overflow-y: hidden;
-}
-
-.header-row {
-  display: grid;
-  grid-auto-flow: column;
-  grid-template-columns: 48px repeat(var(--column-count, 5), minmax(120px, 1fr));
+  flex-wrap: wrap;
   align-items: center;
-  padding: 0.5rem 1rem;
-  background: #f0f0f0;
+  gap: 0.5rem;
+}
+
+.selected-count {
   font-weight: 600;
-  border-bottom: 1px solid #e0e0e0;
-  min-width: max-content;
+  color: #1e293b;
 }
 
-.header-row .cell {
-  padding-right: 1rem;
-  white-space: normal;
-  word-break: break-word;
+.filter-field {
+  margin-left: auto;
+  min-width: min(320px, 100%);
 }
 
-.viewport {
+.summary {
+  margin-left: auto;
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.table-container {
+  position: relative;
   flex: 1;
-  height: 100%;
-  min-width: max-content;
-  overflow-y: auto;
-  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0 1rem 1rem;
+  overflow: hidden;
+}
+
+.grid-table {
+  width: 100%;
+  border-spacing: 0;
+  background: transparent;
+}
+
+.grid-table th.mat-mdc-header-cell {
+  font-weight: 600;
+  color: #0f172a;
+  background: #fff;
+}
+
+.grid-table td.mat-mdc-cell,
+.grid-table th.mat-mdc-header-cell {
+  padding: 0.75rem;
+  border-bottom: 1px solid #edf1f5;
 }
 
 .data-row {
-  display: grid;
-  grid-auto-flow: column;
-  grid-template-columns: 48px repeat(var(--column-count, 5), minmax(120px, 1fr));
-  align-items: center;
-  padding: 0.5rem 1rem;
-  border-bottom: 1px solid #f1f1f1;
   cursor: pointer;
   transition: background 0.2s ease;
-  min-width: max-content;
 }
 
 .data-row:hover {
-  background: #f9f9f9;
+  background: #f5f7fa;
 }
 
 .data-row.active {
-  background: #e7f1ff;
+  background: #e7f0ff;
 }
 
-.cell {
-  padding-right: 1rem;
+.checkbox-cell,
+.expand-cell {
+  width: 48px;
+  padding-right: 0.5rem;
+  text-align: center;
+}
+
+.checkbox-placeholder,
+.expand-placeholder {
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+}
+
+.detail-cell {
+  background: #fbfdff;
+}
+
+.detail-row .mat-mdc-cell {
+  padding: 0;
+  border: none;
+}
+
+.expanded-cell {
+  padding: 0 !important;
+  border: none !important;
+}
+
+.expanded-panel {
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  min-width: 0;
+  padding: 0 1rem 1rem;
+  background: #f9fbff;
 }
 
-.cell.checkbox {
+.expanded-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.expanded-column h5 {
+  margin: 1rem 0 0.5rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.detail-pair {
+  display: grid;
+  grid-template-columns: minmax(120px, 160px) minmax(0, 1fr);
+  gap: 0.5rem;
+  padding: 0.35rem 0;
+  border-bottom: 1px dashed #e2e8f0;
+}
+
+.detail-pair:last-child {
+  border-bottom: none;
+}
+
+.detail-pair dt {
+  margin: 0;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #64748b;
+}
+
+.detail-pair dd {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #0f172a;
+  word-break: break-word;
+}
+
+.detail-placeholder {
+  color: #cbd5f5;
+}
+
+.loading-overlay {
+  position: absolute;
+  inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;
+  background: rgba(255, 255, 255, 0.7);
+  z-index: 2;
+  pointer-events: none;
 }
 
-.loading {
+.empty-state {
   text-align: center;
-  padding: 0.75rem;
-  font-size: 0.9rem;
-  color: #767676;
+  padding: 1.5rem;
+  color: #64748b;
+  font-style: italic;
 }
 
-@media (max-width: 1200px) {
-  .header-row,
-  .data-row {
-    grid-template-columns: 48px repeat(var(--column-count, 5), minmax(96px, 1fr));
+mat-paginator {
+  border-top: 1px solid #e2e8f0;
+  padding: 0.25rem 0.5rem;
+}
+
+@media (max-width: 960px) {
+  .grid-toolbar {
+    flex-direction: column;
+    align-items: flex-start;
   }
-}
 
-@media (max-width: 900px) {
-  .header-row,
-  .data-row {
-    grid-template-columns: 48px repeat(var(--column-count, 5), minmax(88px, 1fr));
+  .filter-field,
+  .summary {
+    margin-left: 0;
+    width: 100%;
+  }
+
+  .detail-pair {
+    grid-template-columns: 1fr;
   }
 }

--- a/frontend/src/app/components/result-grid/result-grid.component.css
+++ b/frontend/src/app/components/result-grid/result-grid.component.css
@@ -26,6 +26,16 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.table-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 .header-row {
@@ -37,16 +47,21 @@
   background: #f0f0f0;
   font-weight: 600;
   border-bottom: 1px solid #e0e0e0;
+  min-width: max-content;
 }
 
 .header-row .cell {
   padding-right: 1rem;
-  white-space: nowrap;
+  white-space: normal;
+  word-break: break-word;
 }
 
 .viewport {
   flex: 1;
   height: 100%;
+  min-width: max-content;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .data-row {
@@ -58,6 +73,7 @@
   border-bottom: 1px solid #f1f1f1;
   cursor: pointer;
   transition: background 0.2s ease;
+  min-width: max-content;
 }
 
 .data-row:hover {
@@ -73,6 +89,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  min-width: 0;
 }
 
 .cell.checkbox {
@@ -91,6 +108,13 @@
 @media (max-width: 1200px) {
   .header-row,
   .data-row {
-    grid-template-columns: 48px repeat(var(--column-count, 5), minmax(100px, 1fr));
+    grid-template-columns: 48px repeat(var(--column-count, 5), minmax(96px, 1fr));
+  }
+}
+
+@media (max-width: 900px) {
+  .header-row,
+  .data-row {
+    grid-template-columns: 48px repeat(var(--column-count, 5), minmax(88px, 1fr));
   }
 }

--- a/frontend/src/app/components/result-grid/result-grid.component.css
+++ b/frontend/src/app/components/result-grid/result-grid.component.css
@@ -17,11 +17,46 @@
 .grid-toolbar {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
-  gap: 0.75rem;
+  align-items: stretch;
+  gap: 0.75rem 1rem;
   padding: 0.75rem 1rem;
   background: #f8fafc;
   border-bottom: 1px solid #e2e8f0;
+}
+
+.pill-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  border: 1px solid #2563eb;
+  background: #fff;
+  color: #1d4ed8;
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.pill-button:hover:not(:disabled) {
+  background: #eff6ff;
+  box-shadow: 0 2px 6px rgba(29, 78, 216, 0.15);
+}
+
+.pill-button:focus-visible {
+  outline: 3px solid rgba(59, 130, 246, 0.35);
+  outline-offset: 2px;
+}
+
+.pill-button:disabled {
+  cursor: not-allowed;
+  border-color: #cbd5f5;
+  color: #94a3b8;
+  background: #f1f5f9;
+  box-shadow: none;
 }
 
 .selection {
@@ -36,15 +71,81 @@
   color: #1e293b;
 }
 
-.filter-field {
+.quick-filter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  width: min(320px, 100%);
   margin-left: auto;
-  min-width: min(320px, 100%);
+}
+
+.quick-filter-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #475569;
+}
+
+.quick-filter-input {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0.35rem 0.2rem 0.75rem;
+  border: 1px solid #cbd5f5;
+  border-radius: 999px;
+  background: #fff;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.quick-filter-input:focus-within {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.quick-filter-input input[type='search'] {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  font-size: 0.95rem;
+  padding: 0.4rem 0.2rem;
+  color: #0f172a;
+}
+
+.quick-filter-input input[type='search']::placeholder {
+  color: #94a3b8;
+}
+
+.quick-filter-input input[type='search']:focus {
+  outline: none;
+}
+
+.clear-button {
+  border: none;
+  background: transparent;
+  font-size: 1.25rem;
+  line-height: 1;
+  color: #94a3b8;
+  padding: 0.2rem 0.3rem;
+  cursor: pointer;
+  transition: color 0.15s ease;
+}
+
+.clear-button:hover,
+.clear-button:focus-visible {
+  color: #1e293b;
+}
+
+.clear-button:focus-visible {
+  outline: 2px solid rgba(37, 99, 235, 0.4);
+  border-radius: 999px;
 }
 
 .summary {
   margin-left: auto;
   font-size: 0.95rem;
   color: #475569;
+  align-self: center;
 }
 
 .table-container {
@@ -52,27 +153,59 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
   padding: 0 1rem 1rem;
   overflow: hidden;
 }
 
+.table-scroll {
+  position: relative;
+  flex: 1;
+  overflow: auto;
+  border-radius: 10px;
+  background: #fff;
+}
+
 .grid-table {
   width: 100%;
+  min-width: max(900px, 100%);
   border-spacing: 0;
   background: transparent;
+  table-layout: auto;
 }
 
 .grid-table th.mat-mdc-header-cell {
   font-weight: 600;
   color: #0f172a;
   background: #fff;
+  white-space: normal;
+  line-height: 1.35;
 }
 
 .grid-table td.mat-mdc-cell,
 .grid-table th.mat-mdc-header-cell {
   padding: 0.75rem;
   border-bottom: 1px solid #edf1f5;
+  word-break: break-word;
+}
+
+.grid-table th.mat-mdc-header-cell:not(.checkbox-header):not(.expand-header),
+.grid-table td.mat-mdc-cell:not(.checkbox-cell):not(.expand-cell) {
+  min-width: 160px;
+}
+
+.grid-table .mat-sort-header-container,
+.grid-table .mat-sort-header-content {
+  white-space: normal;
+  align-items: flex-start;
+  line-height: 1.35;
+}
+
+.grid-table .mat-sort-header-container {
+  gap: 0.35rem;
+}
+
+.grid-table .mat-mdc-cell {
+  vertical-align: top;
 }
 
 .data-row {
@@ -93,6 +226,13 @@
   width: 48px;
   padding-right: 0.5rem;
   text-align: center;
+}
+
+.checkbox-header,
+.expand-header {
+  width: 48px;
+  text-align: center;
+  padding-right: 0.5rem;
 }
 
 .checkbox-placeholder,
@@ -195,7 +335,7 @@ mat-paginator {
     align-items: flex-start;
   }
 
-  .filter-field,
+  .quick-filter,
   .summary {
     margin-left: 0;
     width: 100%;

--- a/frontend/src/app/components/result-grid/result-grid.component.css
+++ b/frontend/src/app/components/result-grid/result-grid.component.css
@@ -346,39 +346,64 @@
   background: #fff;
 }
 
-.page-size-field {
-  min-width: 160px;
-  --mdc-outlined-text-field-container-shape: 999px;
-  --mdc-outlined-text-field-container-padding: 0 0.75rem;
-  --mdc-outlined-text-field-outline-width: 1px;
-  --mdc-outlined-text-field-label-text-color: #475569;
-  --mdc-outlined-text-field-input-text-color: #0f172a;
-  --mdc-outlined-text-field-label-text-size: 0.7rem;
+.page-size-selector {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
-.page-size-field .mat-mdc-form-field-subscript-wrapper {
-  display: none;
-}
-
-.page-size-field .mat-mdc-form-field-flex {
-  padding: 0.35rem 0;
-}
-
-.page-size-field .mat-mdc-select-trigger {
-  font-size: 0.95rem;
+.page-size-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #475569;
   font-weight: 600;
 }
 
-.page-size-field.mat-focused .mat-mdc-form-field-outline-thick {
-  color: #2563eb;
+.page-size-options {
+  display: inline-flex;
+  border: 1px solid #cbd5f5;
+  border-radius: 999px;
+  overflow: hidden;
+  background: #f8fafc;
 }
 
-.page-size-field .mat-mdc-form-field-outline {
-  color: #cbd5f5;
+.page-size-option {
+  border: none;
+  background: transparent;
+  color: #1d4ed8;
+  font-weight: 600;
+  font-size: 0.85rem;
+  padding: 0.35rem 0.9rem;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
 }
 
-.page-size-field .mat-mdc-form-field-outline-end,
-.page-size-field .mat-mdc-form-field-outline-start {
+.page-size-option + .page-size-option {
+  border-left: 1px solid #cbd5f5;
+}
+
+.page-size-option:hover,
+.page-size-option:focus-visible {
+  background: #e0ecff;
+  color: #1e3a8a;
+  outline: none;
+}
+
+.page-size-option.active {
+  background: #1d4ed8;
+  color: #fff;
+}
+
+.page-size-option.active:hover,
+.page-size-option.active:focus-visible {
+  background: #1e40af;
+}
+
+.page-size-option:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.45);
+  outline-offset: 2px;
   border-radius: 999px;
 }
 
@@ -394,8 +419,19 @@ mat-paginator {
     justify-content: space-between;
   }
 
-  .page-size-field {
+  .page-size-selector {
     width: 100%;
+    justify-content: space-between;
+  }
+
+  .page-size-options {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .page-size-option {
+    flex: 1 1 auto;
+    text-align: center;
   }
 }
 

--- a/frontend/src/app/components/result-grid/result-grid.component.css
+++ b/frontend/src/app/components/result-grid/result-grid.component.css
@@ -346,47 +346,40 @@
   background: #fff;
 }
 
-.page-size-control {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  min-width: 140px;
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: #1e293b;
+.page-size-field {
+  min-width: 160px;
+  --mdc-outlined-text-field-container-shape: 999px;
+  --mdc-outlined-text-field-container-padding: 0 0.75rem;
+  --mdc-outlined-text-field-outline-width: 1px;
+  --mdc-outlined-text-field-label-text-color: #475569;
+  --mdc-outlined-text-field-input-text-color: #0f172a;
+  --mdc-outlined-text-field-label-text-size: 0.7rem;
 }
 
-.page-size-label {
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  font-size: 0.7rem;
-  color: #475569;
+.page-size-field .mat-mdc-form-field-subscript-wrapper {
+  display: none;
 }
 
-.page-size-control select {
-  appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  padding: 0.45rem 2.25rem 0.45rem 0.75rem;
-  border: 1px solid #cbd5f5;
-  border-radius: 999px;
-  background: #fff url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="%232563eb" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"%3E%3Cpolyline points="6 9 12 15 18 9"/%3E%3C/svg%3E')
-    no-repeat right 0.75rem center;
-  background-size: 0.85rem;
-  color: #0f172a;
+.page-size-field .mat-mdc-form-field-flex {
+  padding: 0.35rem 0;
+}
+
+.page-size-field .mat-mdc-select-trigger {
   font-size: 0.95rem;
-  cursor: pointer;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  font-weight: 600;
 }
 
-.page-size-control select:focus {
-  outline: none;
-  border-color: #2563eb;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+.page-size-field.mat-focused .mat-mdc-form-field-outline-thick {
+  color: #2563eb;
 }
 
-.page-size-control select:hover {
-  border-color: #94a3f3;
+.page-size-field .mat-mdc-form-field-outline {
+  color: #cbd5f5;
+}
+
+.page-size-field .mat-mdc-form-field-outline-end,
+.page-size-field .mat-mdc-form-field-outline-start {
+  border-radius: 999px;
 }
 
 mat-paginator {
@@ -401,7 +394,7 @@ mat-paginator {
     justify-content: space-between;
   }
 
-  .page-size-control {
+  .page-size-field {
     width: 100%;
   }
 }

--- a/frontend/src/app/components/result-grid/result-grid.component.css
+++ b/frontend/src/app/components/result-grid/result-grid.component.css
@@ -346,12 +346,47 @@
   background: #fff;
 }
 
-.page-size-field {
-  width: 160px;
+.page-size-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 140px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #1e293b;
 }
 
-.page-size-field .mat-mdc-form-field-subscript-wrapper {
-  display: none;
+.page-size-label {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.7rem;
+  color: #475569;
+}
+
+.page-size-control select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  padding: 0.45rem 2.25rem 0.45rem 0.75rem;
+  border: 1px solid #cbd5f5;
+  border-radius: 999px;
+  background: #fff url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="%232563eb" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"%3E%3Cpolyline points="6 9 12 15 18 9"/%3E%3C/svg%3E')
+    no-repeat right 0.75rem center;
+  background-size: 0.85rem;
+  color: #0f172a;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.page-size-control select:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.page-size-control select:hover {
+  border-color: #94a3f3;
 }
 
 mat-paginator {
@@ -362,12 +397,12 @@ mat-paginator {
 }
 
 @media (max-width: 600px) {
-  .page-size-field {
-    width: 100%;
-  }
-
   .paginator-row {
     justify-content: space-between;
+  }
+
+  .page-size-control {
+    width: 100%;
   }
 }
 

--- a/frontend/src/app/components/result-grid/result-grid.component.css
+++ b/frontend/src/app/components/result-grid/result-grid.component.css
@@ -2,16 +2,21 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  width: 100%;
+  min-width: 0;
 }
 
 .result-grid {
   display: flex;
   flex-direction: column;
   height: 100%;
+  width: 100%;
+  min-width: 0;
   background: #fff;
   border: 1px solid #dfe3eb;
   border-radius: 12px;
   overflow: hidden;
+  box-sizing: border-box;
 }
 
 .grid-toolbar {
@@ -155,19 +160,25 @@
   flex-direction: column;
   padding: 0 1rem 1rem;
   overflow: hidden;
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .table-scroll {
   position: relative;
   flex: 1;
-  overflow: auto;
+  overflow-x: auto;
+  overflow-y: auto;
   border-radius: 10px;
   background: #fff;
+  width: 100%;
+  min-width: 0;
 }
 
 .grid-table {
-  width: 100%;
-  min-width: max(900px, 100%);
+  width: max-content;
+  min-width: 100%;
   border-spacing: 0;
   background: transparent;
   table-layout: auto;

--- a/frontend/src/app/components/result-grid/result-grid.component.html
+++ b/frontend/src/app/components/result-grid/result-grid.component.html
@@ -210,12 +210,12 @@
   </div>
 
   <div class="paginator-row">
-    <mat-form-field appearance="outline" class="page-size-field">
-      <mat-label>Items per page</mat-label>
-      <mat-select [value]="pageSize" (selectionChange)="updatePageSize($event.value)">
-        <mat-option *ngFor="let option of pageSizeOptions" [value]="option">{{ option }}</mat-option>
-      </mat-select>
-    </mat-form-field>
+    <label class="page-size-control">
+      <span class="page-size-label">Items per page</span>
+      <select [ngModel]="pageSize" (ngModelChange)="updatePageSize($event)">
+        <option *ngFor="let option of pageSizeOptions" [ngValue]="option">{{ option }}</option>
+      </select>
+    </label>
 
     <mat-paginator
       [length]="paginatorLength"

--- a/frontend/src/app/components/result-grid/result-grid.component.html
+++ b/frontend/src/app/components/result-grid/result-grid.component.html
@@ -209,12 +209,21 @@
     </div>
   </div>
 
-  <mat-paginator
-    [length]="paginatorLength"
-    [pageIndex]="pageIndex"
-    [pageSize]="pageSize"
-    [pageSizeOptions]="pageSizeOptions"
-    (page)="handlePage($event)"
-    aria-label="Result grid pagination"
-  ></mat-paginator>
+  <div class="paginator-row">
+    <mat-form-field appearance="outline" class="page-size-field">
+      <mat-label>Items per page</mat-label>
+      <mat-select [value]="pageSize" (selectionChange)="updatePageSize($event.value)">
+        <mat-option *ngFor="let option of pageSizeOptions" [value]="option">{{ option }}</mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-paginator
+      [length]="paginatorLength"
+      [pageIndex]="pageIndex"
+      [pageSize]="pageSize"
+      (page)="handlePage($event)"
+      [hidePageSize]="true"
+      aria-label="Result grid pagination"
+    ></mat-paginator>
+  </div>
 </div>

--- a/frontend/src/app/components/result-grid/result-grid.component.html
+++ b/frontend/src/app/components/result-grid/result-grid.component.html
@@ -1,56 +1,211 @@
 <div class="result-grid">
   <div class="grid-toolbar">
     <div class="selection">
-      <button type="button" (click)="toggleSelectPage()">Toggle Page</button>
-      <button type="button" (click)="selectLoaded()">Select Loaded</button>
-      <button type="button" (click)="requestFilteredSelection()">Select Filtered</button>
-      <span>{{ selectedCount }} selected</span>
+      <button mat-stroked-button color="primary" (click)="toggleSelectPage()" [disabled]="currentPageRows.length === 0">
+        {{ isPageFullySelected ? 'Deselect page' : 'Select page' }}
+      </button>
+      <button mat-stroked-button color="primary" (click)="selectLoaded()" [disabled]="filteredRows.length === 0">
+        Select loaded
+      </button>
+      <button mat-stroked-button color="primary" (click)="requestFilteredSelection()" [disabled]="filteredRows.length === 0">
+        Select filtered
+      </button>
+      <span class="selected-count">{{ selectedCount }} selected</span>
     </div>
-    <div class="summary" *ngIf="total !== null">
-      <span>Total records: {{ total }}</span>
+
+    <mat-form-field appearance="outline" class="filter-field">
+      <mat-label>Quick filter</mat-label>
+      <input
+        matInput
+        type="search"
+        placeholder="Search results"
+        [(ngModel)]="filterText"
+        (input)="handleFilterChange()"
+      />
+      <button mat-icon-button matSuffix *ngIf="filterText" (click)="clearFilter()" aria-label="Clear quick filter">
+        <mat-icon>close</mat-icon>
+      </button>
+    </mat-form-field>
+
+    <div class="summary" *ngIf="total !== null; else loadedCount">
+      Total records: {{ total }}
     </div>
-    <div class="summary" *ngIf="total === null">
-      <span>Records shown: {{ rows.length }}</span>
-    </div>
+    <ng-template #loadedCount>
+      <div class="summary">Records shown: {{ filteredRows.length }}</div>
+    </ng-template>
   </div>
 
-  <div class="table-wrapper">
-    <div class="table-content">
-      <div class="header-row" [style.--column-count]="baseColumns.length + columns.length">
-        <div class="cell checkbox">&nbsp;</div>
-        <div class="cell" *ngFor="let column of baseColumns">{{ column.label }}</div>
-        <div class="cell" *ngFor="let column of columns">{{ column.label }}</div>
-      </div>
+  <div class="table-container">
+    <div class="loading-overlay" *ngIf="loading">
+      <mat-progress-spinner mode="indeterminate" diameter="36"></mat-progress-spinner>
+    </div>
 
-      <cdk-virtual-scroll-viewport
-        class="viewport"
-        [itemSize]="48"
-        (scrolledIndexChange)="onScrolledIndexChange($event)"
-      >
-        <div
-          class="data-row"
-          *cdkVirtualFor="let row of rows"
-          [class.active]="row.breakId === selectedRowId"
-          [style.--column-count]="baseColumns.length + columns.length"
-          (click)="select(row)"
-        >
-          <div class="cell checkbox" (click)="$event.stopPropagation()">
-            <input
-              type="checkbox"
+    <table
+      mat-table
+      [dataSource]="tableData"
+      matSort
+      (matSortChange)="handleSort($event)"
+      multiTemplateDataRows
+      class="grid-table mat-elevation-z2"
+    >
+      <ng-container matColumnDef="select">
+        <th mat-header-cell *matHeaderCellDef>
+          <mat-checkbox
+            color="primary"
+            [checked]="isPageFullySelected"
+            [indeterminate]="isPagePartiallySelected"
+            [disabled]="currentPageRows.length === 0"
+            (change)="setPageSelection($event.checked)"
+            aria-label="Toggle page selection"
+          ></mat-checkbox>
+        </th>
+        <td mat-cell *matCellDef="let row" class="checkbox-cell">
+          <ng-container *ngIf="isBaseRow(row); else detailCheckbox">
+            <mat-checkbox
+              color="primary"
+              (click)="$event.stopPropagation()"
+              (change)="toggleSelection(row, $event.checked)"
               [checked]="isSelected(row)"
-              (change)="toggleSelection(row, $event.target.checked)"
-            />
+              [aria-label]="'Select break ' + row.breakId"
+            ></mat-checkbox>
+          </ng-container>
+          <ng-template #detailCheckbox>
+            <span class="checkbox-placeholder"></span>
+          </ng-template>
+        </td>
+      </ng-container>
+
+      <ng-container *ngFor="let column of baseColumns" matColumnDef="{{ column.key }}">
+        <th
+          mat-header-cell
+          *matHeaderCellDef
+          mat-sort-header="{{ column.key }}"
+          [disabled]="!isSortable(column.key)"
+        >
+          {{ column.label }}
+        </th>
+        <td mat-cell *matCellDef="let row" [class.detail-cell]="!isBaseRow(row)">
+          <ng-container *ngIf="isBaseRow(row); else detailValuePlaceholder">
+            {{ getBaseDisplay(row, column.key) }}
+          </ng-container>
+        </td>
+      </ng-container>
+
+      <ng-container *ngFor="let column of columns" matColumnDef="{{ column.key }}">
+        <th
+          mat-header-cell
+          *matHeaderCellDef
+          mat-sort-header="{{ column.key }}"
+          [disabled]="!column.sortable"
+        >
+          {{ column.label }}
+        </th>
+        <td mat-cell *matCellDef="let row" [class.detail-cell]="!isBaseRow(row)">
+          <ng-container *ngIf="isBaseRow(row); else detailValuePlaceholder">
+            {{ displayAttribute(row, column.key) }}
+          </ng-container>
+        </td>
+      </ng-container>
+
+      <ng-template #detailValuePlaceholder>
+        <span class="detail-placeholder">—</span>
+      </ng-template>
+
+      <ng-container matColumnDef="expand">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let row" class="expand-cell">
+          <ng-container *ngIf="isBaseRow(row); else detailExpandPlaceholder">
+            <button
+              mat-icon-button
+              color="primary"
+              (click)="toggleExpandedRow(row); $event.stopPropagation()"
+              [attr.aria-label]="expandedRow === row ? 'Collapse details' : 'Expand details'"
+            >
+              <mat-icon>{{ expandedRow === row ? 'expand_less' : 'expand_more' }}</mat-icon>
+            </button>
+          </ng-container>
+        </td>
+      </ng-container>
+
+      <ng-template #detailExpandPlaceholder>
+        <span class="expand-placeholder"></span>
+      </ng-template>
+
+      <ng-container matColumnDef="expandedDetail">
+        <td mat-cell *matCellDef="let row" [attr.colspan]="columnsWithExpand.length" class="expanded-cell">
+          <div class="expanded-panel" [@detailExpand]="row.element === expandedRow ? 'expanded' : 'collapsed'">
+            <div class="expanded-grid">
+              <div class="expanded-column">
+                <h5>Break metadata</h5>
+                <dl>
+                  <div class="detail-pair">
+                    <dt>Break ID</dt>
+                    <dd>{{ row.element.breakId }}</dd>
+                  </div>
+                  <div class="detail-pair">
+                    <dt>Run ID</dt>
+                    <dd>{{ row.element.runId ?? '—' }}</dd>
+                  </div>
+                  <div class="detail-pair">
+                    <dt>Run time</dt>
+                    <dd>{{ row.element.runDateTime || '—' }}</dd>
+                  </div>
+                  <div class="detail-pair">
+                    <dt>Status</dt>
+                    <dd>{{ row.element.breakItem.status }}</dd>
+                  </div>
+                  <div class="detail-pair">
+                    <dt>Trigger</dt>
+                    <dd>{{ row.element.triggerType || '—' }}</dd>
+                  </div>
+                </dl>
+              </div>
+              <div class="expanded-column">
+                <h5>Attributes</h5>
+                <dl>
+                  <ng-container *ngFor="let column of columns">
+                    <ng-container *ngIf="displayAttribute(row.element, column.key) !== '—'">
+                      <div class="detail-pair">
+                        <dt>{{ column.label }}</dt>
+                        <dd>{{ displayAttribute(row.element, column.key) }}</dd>
+                      </div>
+                    </ng-container>
+                  </ng-container>
+                  <ng-container *ngIf="columns.length === 0">
+                    <div class="detail-pair">
+                      <dt>Attributes</dt>
+                      <dd>No additional attributes available.</dd>
+                    </div>
+                  </ng-container>
+                </dl>
+              </div>
+            </div>
           </div>
-          <div class="cell">{{ row.breakId }}</div>
-          <div class="cell">{{ row.runDateTime || '—' }}</div>
-          <div class="cell status">{{ row.breakItem.status }}</div>
-          <div class="cell">{{ row.breakItem.breakType }}</div>
-          <div class="cell">{{ row.triggerType || '—' }}</div>
-          <div class="cell" *ngFor="let column of columns">{{ displayAttribute(row, column.key) }}</div>
-        </div>
-      </cdk-virtual-scroll-viewport>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="columnsWithExpand"></tr>
+      <tr
+        mat-row
+        *matRowDef="let row; columns: columnsWithExpand"
+        class="data-row"
+        [class.active]="isBaseRow(row) && row.breakId === selectedRowId"
+        (click)="onRowClick(row)"
+      ></tr>
+      <tr mat-row *matRowDef="let row; columns: detailColumns; when: isExpansionDetailRow" class="detail-row"></tr>
+    </table>
+
+    <div class="empty-state" *ngIf="!loading && filteredRows.length === 0">
+      No results match the current filters.
     </div>
   </div>
 
-  <div class="loading" *ngIf="loading">Loading…</div>
+  <mat-paginator
+    [length]="paginatorLength"
+    [pageIndex]="pageIndex"
+    [pageSize]="pageSize"
+    [pageSizeOptions]="pageSizeOptions"
+    (page)="handlePage($event)"
+    aria-label="Result grid pagination"
+  ></mat-paginator>
 </div>

--- a/frontend/src/app/components/result-grid/result-grid.component.html
+++ b/frontend/src/app/components/result-grid/result-grid.component.html
@@ -1,31 +1,38 @@
 <div class="result-grid">
   <div class="grid-toolbar">
     <div class="selection">
-      <button mat-stroked-button color="primary" (click)="toggleSelectPage()" [disabled]="currentPageRows.length === 0">
+      <button type="button" class="pill-button" (click)="toggleSelectPage()" [disabled]="currentPageRows.length === 0">
         {{ isPageFullySelected ? 'Deselect page' : 'Select page' }}
       </button>
-      <button mat-stroked-button color="primary" (click)="selectLoaded()" [disabled]="filteredRows.length === 0">
+      <button type="button" class="pill-button" (click)="selectLoaded()" [disabled]="filteredRows.length === 0">
         Select loaded
       </button>
-      <button mat-stroked-button color="primary" (click)="requestFilteredSelection()" [disabled]="filteredRows.length === 0">
+      <button
+        type="button"
+        class="pill-button"
+        (click)="requestFilteredSelection()"
+        [disabled]="filteredRows.length === 0"
+      >
         Select filtered
       </button>
       <span class="selected-count">{{ selectedCount }} selected</span>
     </div>
 
-    <mat-form-field appearance="outline" class="filter-field">
-      <mat-label>Quick filter</mat-label>
-      <input
-        matInput
-        type="search"
-        placeholder="Search results"
-        [(ngModel)]="filterText"
-        (input)="handleFilterChange()"
-      />
-      <button mat-icon-button matSuffix *ngIf="filterText" (click)="clearFilter()" aria-label="Clear quick filter">
-        <mat-icon>close</mat-icon>
-      </button>
-    </mat-form-field>
+    <div class="quick-filter">
+      <label class="quick-filter-label" for="quick-filter-input">Quick filter</label>
+      <div class="quick-filter-input">
+        <input
+          id="quick-filter-input"
+          type="search"
+          placeholder="Search results"
+          [(ngModel)]="filterText"
+          (input)="handleFilterChange()"
+        />
+        <button type="button" class="clear-button" *ngIf="filterText" (click)="clearFilter()" aria-label="Clear quick filter">
+          ×
+        </button>
+      </div>
+    </div>
 
     <div class="summary" *ngIf="total !== null; else loadedCount">
       Total records: {{ total }}
@@ -40,16 +47,17 @@
       <mat-progress-spinner mode="indeterminate" diameter="36"></mat-progress-spinner>
     </div>
 
-    <table
-      mat-table
-      [dataSource]="tableData"
-      matSort
-      (matSortChange)="handleSort($event)"
-      multiTemplateDataRows
-      class="grid-table mat-elevation-z2"
-    >
+    <div class="table-scroll">
+      <table
+        mat-table
+        [dataSource]="tableData"
+        matSort
+        (matSortChange)="handleSort($event)"
+        multiTemplateDataRows
+        class="grid-table mat-elevation-z2"
+      >
       <ng-container matColumnDef="select">
-        <th mat-header-cell *matHeaderCellDef>
+        <th mat-header-cell *matHeaderCellDef class="checkbox-header">
           <mat-checkbox
             color="primary"
             [checked]="isPageFullySelected"
@@ -112,7 +120,7 @@
       </ng-template>
 
       <ng-container matColumnDef="expand">
-        <th mat-header-cell *matHeaderCellDef></th>
+        <th mat-header-cell *matHeaderCellDef class="expand-header"></th>
         <td mat-cell *matCellDef="let row" class="expand-cell">
           <ng-container *ngIf="isBaseRow(row); else detailExpandPlaceholder">
             <button
@@ -193,7 +201,8 @@
         (click)="onRowClick(row)"
       ></tr>
       <tr mat-row *matRowDef="let row; columns: detailColumns; when: isExpansionDetailRow" class="detail-row"></tr>
-    </table>
+      </table>
+    </div>
 
     <div class="empty-state" *ngIf="!loading && filteredRows.length === 0">
       No results match the current filters.

--- a/frontend/src/app/components/result-grid/result-grid.component.html
+++ b/frontend/src/app/components/result-grid/result-grid.component.html
@@ -210,12 +210,21 @@
   </div>
 
   <div class="paginator-row">
-    <mat-form-field appearance="outline" floatLabel="always" class="page-size-field">
-      <mat-label>Items per page</mat-label>
-      <mat-select [value]="pageSize" (selectionChange)="updatePageSize($event.value)">
-        <mat-option *ngFor="let option of pageSizeOptions" [value]="option">{{ option }}</mat-option>
-      </mat-select>
-    </mat-form-field>
+    <div class="page-size-selector" role="group" aria-label="Items per page">
+      <span class="page-size-label">Items per page</span>
+      <div class="page-size-options">
+        <button
+          type="button"
+          class="page-size-option"
+          *ngFor="let option of pageSizeOptions"
+          [class.active]="pageSize === option"
+          (click)="updatePageSize(option)"
+          [attr.aria-pressed]="pageSize === option"
+        >
+          {{ option }}
+        </button>
+      </div>
+    </div>
 
     <mat-paginator
       [length]="paginatorLength"

--- a/frontend/src/app/components/result-grid/result-grid.component.html
+++ b/frontend/src/app/components/result-grid/result-grid.component.html
@@ -15,35 +15,41 @@
   </div>
 
   <div class="table-wrapper">
-    <div class="header-row" [style.--column-count]="baseColumns.length + columns.length">
-      <div class="cell checkbox">&nbsp;</div>
-      <div class="cell" *ngFor="let column of baseColumns">{{ column.label }}</div>
-      <div class="cell" *ngFor="let column of columns">{{ column.label }}</div>
-    </div>
-
-    <cdk-virtual-scroll-viewport
-      class="viewport"
-      [itemSize]="48"
-      (scrolledIndexChange)="onScrolledIndexChange($event)"
-    >
-      <div
-        class="data-row"
-        *cdkVirtualFor="let row of rows"
-        [class.active]="row.breakId === selectedRowId"
-        [style.--column-count]="baseColumns.length + columns.length"
-        (click)="select(row)"
-      >
-        <div class="cell checkbox" (click)="$event.stopPropagation()">
-          <input type="checkbox" [checked]="isSelected(row)" (change)="toggleSelection(row, $event.target.checked)" />
-        </div>
-        <div class="cell">{{ row.breakId }}</div>
-        <div class="cell">{{ row.runDateTime || '—' }}</div>
-        <div class="cell status">{{ row.breakItem.status }}</div>
-        <div class="cell">{{ row.breakItem.breakType }}</div>
-        <div class="cell">{{ row.triggerType || '—' }}</div>
-        <div class="cell" *ngFor="let column of columns">{{ displayAttribute(row, column.key) }}</div>
+    <div class="table-content">
+      <div class="header-row" [style.--column-count]="baseColumns.length + columns.length">
+        <div class="cell checkbox">&nbsp;</div>
+        <div class="cell" *ngFor="let column of baseColumns">{{ column.label }}</div>
+        <div class="cell" *ngFor="let column of columns">{{ column.label }}</div>
       </div>
-    </cdk-virtual-scroll-viewport>
+
+      <cdk-virtual-scroll-viewport
+        class="viewport"
+        [itemSize]="48"
+        (scrolledIndexChange)="onScrolledIndexChange($event)"
+      >
+        <div
+          class="data-row"
+          *cdkVirtualFor="let row of rows"
+          [class.active]="row.breakId === selectedRowId"
+          [style.--column-count]="baseColumns.length + columns.length"
+          (click)="select(row)"
+        >
+          <div class="cell checkbox" (click)="$event.stopPropagation()">
+            <input
+              type="checkbox"
+              [checked]="isSelected(row)"
+              (change)="toggleSelection(row, $event.target.checked)"
+            />
+          </div>
+          <div class="cell">{{ row.breakId }}</div>
+          <div class="cell">{{ row.runDateTime || '—' }}</div>
+          <div class="cell status">{{ row.breakItem.status }}</div>
+          <div class="cell">{{ row.breakItem.breakType }}</div>
+          <div class="cell">{{ row.triggerType || '—' }}</div>
+          <div class="cell" *ngFor="let column of columns">{{ displayAttribute(row, column.key) }}</div>
+        </div>
+      </cdk-virtual-scroll-viewport>
+    </div>
   </div>
 
   <div class="loading" *ngIf="loading">Loading…</div>

--- a/frontend/src/app/components/result-grid/result-grid.component.html
+++ b/frontend/src/app/components/result-grid/result-grid.component.html
@@ -210,12 +210,12 @@
   </div>
 
   <div class="paginator-row">
-    <label class="page-size-control">
-      <span class="page-size-label">Items per page</span>
-      <select [ngModel]="pageSize" (ngModelChange)="updatePageSize($event)">
-        <option *ngFor="let option of pageSizeOptions" [ngValue]="option">{{ option }}</option>
-      </select>
-    </label>
+    <mat-form-field appearance="outline" floatLabel="always" class="page-size-field">
+      <mat-label>Items per page</mat-label>
+      <mat-select [value]="pageSize" (selectionChange)="updatePageSize($event.value)">
+        <mat-option *ngFor="let option of pageSizeOptions" [value]="option">{{ option }}</mat-option>
+      </mat-select>
+    </mat-form-field>
 
     <mat-paginator
       [length]="paginatorLength"

--- a/frontend/src/app/components/result-grid/result-grid.component.ts
+++ b/frontend/src/app/components/result-grid/result-grid.component.ts
@@ -4,10 +4,12 @@ import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, ViewC
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatPaginator, MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSortModule, Sort } from '@angular/material/sort';
+import { MatSelectModule } from '@angular/material/select';
 import { MatTableModule } from '@angular/material/table';
 import { BreakResultRow, GridColumn } from '../../models/api-models';
 
@@ -26,9 +28,11 @@ type TableRow = BreakResultRow | DetailRow;
     FormsModule,
     MatButtonModule,
     MatCheckboxModule,
+    MatFormFieldModule,
     MatIconModule,
     MatPaginatorModule,
     MatProgressSpinnerModule,
+    MatSelectModule,
     MatSortModule,
     MatTableModule
   ],

--- a/frontend/src/app/components/result-grid/result-grid.component.ts
+++ b/frontend/src/app/components/result-grid/result-grid.component.ts
@@ -8,10 +8,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatPaginator, MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSortModule, Sort } from '@angular/material/sort';
-import { MatSelectModule } from '@angular/material/select';
 import { MatTableModule } from '@angular/material/table';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatOptionModule } from '@angular/material/core';
 import { BreakResultRow, GridColumn } from '../../models/api-models';
 
 interface DetailRow {
@@ -33,10 +30,7 @@ type TableRow = BreakResultRow | DetailRow;
     MatPaginatorModule,
     MatProgressSpinnerModule,
     MatSortModule,
-    MatSelectModule,
-    MatTableModule,
-    MatFormFieldModule,
-    MatOptionModule
+    MatTableModule
   ],
   templateUrl: './result-grid.component.html',
   styleUrls: ['./result-grid.component.css'],

--- a/frontend/src/app/components/result-grid/result-grid.component.ts
+++ b/frontend/src/app/components/result-grid/result-grid.component.ts
@@ -8,7 +8,9 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSortModule, Sort } from '@angular/material/sort';
+import { MatSelectModule } from '@angular/material/select';
 import { MatTableModule } from '@angular/material/table';
+import { MatFormFieldModule } from '@angular/material/form-field';
 import { BreakResultRow, GridColumn } from '../../models/api-models';
 
 interface DetailRow {
@@ -30,7 +32,9 @@ type TableRow = BreakResultRow | DetailRow;
     MatPaginatorModule,
     MatProgressSpinnerModule,
     MatSortModule,
-    MatTableModule
+    MatSelectModule,
+    MatTableModule,
+    MatFormFieldModule
   ],
   templateUrl: './result-grid.component.html',
   styleUrls: ['./result-grid.component.css'],

--- a/frontend/src/app/components/result-grid/result-grid.component.ts
+++ b/frontend/src/app/components/result-grid/result-grid.component.ts
@@ -4,12 +4,10 @@ import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, ViewC
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatPaginator, MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSortModule, Sort } from '@angular/material/sort';
-import { MatSelectModule } from '@angular/material/select';
 import { MatTableModule } from '@angular/material/table';
 import { BreakResultRow, GridColumn } from '../../models/api-models';
 
@@ -28,11 +26,9 @@ type TableRow = BreakResultRow | DetailRow;
     FormsModule,
     MatButtonModule,
     MatCheckboxModule,
-    MatFormFieldModule,
     MatIconModule,
     MatPaginatorModule,
     MatProgressSpinnerModule,
-    MatSelectModule,
     MatSortModule,
     MatTableModule
   ],

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -6,6 +6,7 @@
     <base href="/">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="favicon.png">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
   </head>
   <body>
     <app-root></app-root>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,3 +1,5 @@
+@import '@angular/material/prebuilt-themes/indigo-pink.css';
+
 body {
   margin: 0;
   background: #e2e8f0;
@@ -10,7 +12,7 @@ body {
   box-shadow: 0 2px 8px rgba(15, 23, 42, 0.1);
 }
 
-button {
+button:not(.mat-mdc-button-base) {
   cursor: pointer;
   border: none;
   background: #2563eb;
@@ -20,11 +22,11 @@ button {
   transition: background 0.2s ease;
 }
 
-button:disabled {
+button:not(.mat-mdc-button-base):disabled {
   background: #94a3b8;
   cursor: not-allowed;
 }
 
-button:not(:disabled):hover {
+button:not(.mat-mdc-button-base):not(:disabled):hover {
   background: #1d4ed8;
 }


### PR DESCRIPTION
## Summary
- update the analyst workspace layout so the sidebar, result grid, and detail panel stay on screen at smaller widths
- constrain the result grid to its container, allow header text to wrap, and adjust column sizing for responsiveness
- populate supplemental columns in the result grid by falling back to source payload values when attributes are absent

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d819c8fcf4832b842dd950ce77aef3