### PR TITLE
Revamp analyst workspace inline break workflow

### DIFF
--- a/frontend/src/app/components/analyst-workspace/analyst-workspace.component.css
+++ b/frontend/src/app/components/analyst-workspace/analyst-workspace.component.css
@@ -19,7 +19,7 @@
   min-width: 0;
 }
 
-.workspace button:not(.mat-icon-button):not(.pill-button):not(.clear-button):not(.page-size-option) {
+.workspace button:not(:is(.mat-icon-button, .pill-button, .clear-button, .page-size-option)) {
   border-radius: 10px;
   border: 1px solid #d2d9f3;
   background: linear-gradient(135deg, #ffffff 0%, #f3f6ff 100%);
@@ -30,18 +30,18 @@
   transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
 }
 
-.workspace button:not(.mat-icon-button):not(.pill-button):not(.clear-button):not(.page-size-option):hover:not(:disabled) {
+.workspace button:not(:is(.mat-icon-button, .pill-button, .clear-button, .page-size-option)):hover:not(:disabled) {
   transform: translateY(-1px);
   border-color: #94a3f3;
   box-shadow: 0 8px 16px rgba(79, 70, 229, 0.18);
 }
 
-.workspace button:not(.mat-icon-button):not(.pill-button):not(.clear-button):not(.page-size-option):focus-visible {
+.workspace button:not(:is(.mat-icon-button, .pill-button, .clear-button, .page-size-option)):focus-visible {
   outline: 3px solid rgba(79, 70, 229, 0.35);
   outline-offset: 2px;
 }
 
-.workspace button:not(.mat-icon-button):not(.pill-button):not(.clear-button):not(.page-size-option):disabled {
+.workspace button:not(:is(.mat-icon-button, .pill-button, .clear-button, .page-size-option)):disabled {
   cursor: not-allowed;
   color: #94a3b8;
   border-color: #e2e8f0;

--- a/frontend/src/app/components/analyst-workspace/analyst-workspace.component.css
+++ b/frontend/src/app/components/analyst-workspace/analyst-workspace.component.css
@@ -1,6 +1,6 @@
 .workspace {
   display: grid;
-  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr) minmax(280px, 360px);
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
   gap: 1.5rem;
   padding: 1.5rem;
   min-height: calc(100vh - 3rem);
@@ -15,9 +15,38 @@
 }
 
 .sidebar,
-.main,
-.detail-panel {
+.main {
   min-width: 0;
+}
+
+.workspace button:not(.mat-icon-button):not(.pill-button):not(.clear-button):not(.page-size-option) {
+  border-radius: 10px;
+  border: 1px solid #d2d9f3;
+  background: linear-gradient(135deg, #ffffff 0%, #f3f6ff 100%);
+  color: #1f2a4a;
+  font-weight: 600;
+  padding: 0.55rem 1.1rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.workspace button:not(.mat-icon-button):not(.pill-button):not(.clear-button):not(.page-size-option):hover:not(:disabled) {
+  transform: translateY(-1px);
+  border-color: #94a3f3;
+  box-shadow: 0 8px 16px rgba(79, 70, 229, 0.18);
+}
+
+.workspace button:not(.mat-icon-button):not(.pill-button):not(.clear-button):not(.page-size-option):focus-visible {
+  outline: 3px solid rgba(79, 70, 229, 0.35);
+  outline-offset: 2px;
+}
+
+.workspace button:not(.mat-icon-button):not(.pill-button):not(.clear-button):not(.page-size-option):disabled {
+  cursor: not-allowed;
+  color: #94a3b8;
+  border-color: #e2e8f0;
+  box-shadow: none;
+  background: #f8fafc;
 }
 
 .saved-views {
@@ -57,16 +86,14 @@
 
 .view-item button {
   text-align: left;
-  padding: 0.4rem 0.6rem;
-  border: 1px solid #d0d0d0;
-  border-radius: 6px;
-  background: #fafafa;
-  cursor: pointer;
+  width: 100%;
 }
 
 .view-item button.active {
-  background: #e6f0ff;
-  border-color: #4c83ff;
+  background: linear-gradient(135deg, #4338ca 0%, #6366f1 100%);
+  border-color: transparent;
+  color: #fff;
+  box-shadow: 0 8px 18px rgba(99, 102, 241, 0.3);
 }
 
 .view-actions button {
@@ -76,6 +103,11 @@
   font-size: 1rem;
   line-height: 1;
   padding: 0.1rem 0.3rem;
+  color: #475569;
+}
+
+.view-actions button:hover {
+  color: #111827;
 }
 
 .main {
@@ -90,18 +122,19 @@
 }
 
 .tab-bar button {
-  border: 1px solid #d0d5dd;
-  background: #fff;
-  padding: 0.5rem 1rem;
   border-radius: 999px;
-  cursor: pointer;
-  font-weight: 500;
+  border: 1px solid transparent;
+  background: linear-gradient(135deg, #f3f4ff 0%, #dee1ff 100%);
+  color: #1f2a4a;
+  padding: 0.55rem 1.25rem;
+  font-weight: 600;
+  box-shadow: 0 4px 10px rgba(79, 70, 229, 0.15);
 }
 
 .tab-bar button.active {
-  background: #274bbf;
+  background: linear-gradient(135deg, #4338ca 0%, #6366f1 100%);
   color: #fff;
-  border-color: #274bbf;
+  box-shadow: 0 10px 20px rgba(79, 70, 229, 0.3);
 }
 
 .filters {
@@ -156,6 +189,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 1rem;
 }
 
 .column-filter-rows {
@@ -199,6 +233,7 @@
   grid-column: 1 / -1;
   display: flex;
   gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .result-layout {
@@ -229,44 +264,6 @@
   min-height: 0;
 }
 
-.detail-panel {
-  background: #fff;
-  border: 1px solid #e1e1e1;
-  border-radius: 8px;
-  padding: 1rem;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-
-.detail-scroll {
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
-  padding-right: 0.5rem;
-  margin-right: -0.5rem;
-}
-
-.detail-scroll urp-break-detail {
-  display: block;
-}
-
-@media (max-width: 1440px) {
-  .workspace {
-    grid-template-columns: minmax(240px, 300px) minmax(0, 1fr) minmax(240px, 320px);
-  }
-}
-
-@media (max-width: 1200px) {
-  .workspace {
-    grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
-  }
-
-  .detail-panel {
-    grid-column: span 2;
-  }
-}
-
 @media (max-width: 992px) {
   .workspace {
     grid-template-columns: 1fr;
@@ -274,13 +271,8 @@
   }
 
   .sidebar,
-  .main,
-  .detail-panel {
+  .main {
     grid-column: 1 / -1;
-  }
-
-  .detail-panel {
-    order: 3;
   }
 
   .main {
@@ -374,7 +366,7 @@
 
 @media (max-width: 1440px) {
   .workspace {
-    grid-template-columns: 280px 1fr 320px;
+    grid-template-columns: minmax(240px, 300px) minmax(0, 1fr);
   }
 
   .filters {
@@ -384,21 +376,6 @@
   .column-filter-row {
     grid-template-columns: repeat(2, minmax(160px, 1fr)) auto;
     grid-template-rows: auto auto;
-  }
-}
-
-@media (max-width: 1080px) {
-  .workspace {
-    grid-template-columns: 1fr;
-  }
-
-  .sidebar,
-  .detail-panel {
-    order: -1;
-  }
-
-  .detail-panel {
-    display: none;
   }
 }
 

--- a/frontend/src/app/components/analyst-workspace/analyst-workspace.component.css
+++ b/frontend/src/app/components/analyst-workspace/analyst-workspace.component.css
@@ -147,6 +147,18 @@
   border: 1px solid #e1e1e1;
 }
 
+.sr-only-break {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .filters label {
   display: flex;
   flex-direction: column;

--- a/frontend/src/app/components/analyst-workspace/analyst-workspace.component.html
+++ b/frontend/src/app/components/analyst-workspace/analyst-workspace.component.html
@@ -288,3 +288,12 @@
     </section>
   </main>
 </div>
+
+<ng-container *ngIf="activeBreakId !== null">
+  <ng-container *ngIf="selectedBreak$ | async as accessibleBreak">
+    <section class="break-detail sr-only-break" aria-live="polite">
+      <p>Break {{ accessibleBreak.id }}</p>
+      <p>Status: {{ accessibleBreak.status }}</p>
+    </section>
+  </ng-container>
+</ng-container>

--- a/frontend/src/app/components/analyst-workspace/analyst-workspace.component.html
+++ b/frontend/src/app/components/analyst-workspace/analyst-workspace.component.html
@@ -182,10 +182,13 @@
               [total]="total$ | async"
               [selectedRowId]="selectedRow?.breakId || null"
               [selectedBreakIds]="selectedBreakIds"
+              [workflowSummary]="workflowSummary$ | async"
               (selectRow)="handleRowSelect($event)"
               (requestMore)="loadMore()"
               (selectionChange)="handleSelectionChange($event)"
               (selectFiltered)="selectFiltered()"
+              (addComment)="handleAddComment($event)"
+              (updateStatus)="handleUpdateStatus($event)"
             ></urp-result-grid>
           </ng-container>
         </ng-container>
@@ -284,15 +287,4 @@
       <urp-system-activity [entries]="activity"></urp-system-activity>
     </section>
   </main>
-
-  <aside class="detail-panel" *ngIf="isActiveTab('runs') || isActiveTab('breaks')">
-    <div class="detail-scroll">
-      <urp-break-detail
-        [breakItem]="selectedBreak$ | async"
-        [workflowSummary]="workflowSummary$ | async"
-        (addComment)="state.addComment($event.breakId, $event.comment, $event.action)"
-        (updateStatus)="state.updateStatus($event.breakId, { status: $event.status, comment: $event.comment })"
-      ></urp-break-detail>
-    </div>
-  </aside>
 </div>

--- a/frontend/src/app/components/analyst-workspace/analyst-workspace.component.ts
+++ b/frontend/src/app/components/analyst-workspace/analyst-workspace.component.ts
@@ -87,6 +87,8 @@ export class AnalystWorkspaceComponent implements OnInit, OnDestroy {
 
   selectedBreakIds: number[] = [];
   selectedRow: BreakResultRow | null = null;
+  activeBreakId: number | null = null;
+  hasInlineDetail = false;
 
   private readonly destroy$ = new Subject<void>();
 
@@ -108,6 +110,8 @@ export class AnalystWorkspaceComponent implements OnInit, OnDestroy {
           this.applyFilters();
         } else {
           this.selectedBreakIds = [];
+          this.selectedRow = null;
+          this.activeBreakId = null;
         }
       });
 
@@ -129,6 +133,32 @@ export class AnalystWorkspaceComponent implements OnInit, OnDestroy {
         this.columnFilters = this.columnFilters
           .filter((row) => validKeys.has(row.columnKey))
           .map((row) => this.ensureOperator(row));
+      });
+
+    this.rows$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((rows) => {
+        if (!rows) {
+          this.hasInlineDetail = false;
+          return;
+        }
+        if (this.activeBreakId != null) {
+          const match = rows.find((row) => row.breakId === this.activeBreakId) ?? null;
+          this.selectedRow = match;
+          this.hasInlineDetail = !!match;
+        } else {
+          this.hasInlineDetail = false;
+        }
+      });
+
+    this.selectedBreak$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((selected) => {
+        this.activeBreakId = selected?.id ?? null;
+        if (!selected) {
+          this.hasInlineDetail = false;
+          this.selectedRow = null;
+        }
       });
   }
 
@@ -300,6 +330,8 @@ export class AnalystWorkspaceComponent implements OnInit, OnDestroy {
 
   handleRowSelect(row: BreakResultRow): void {
     this.selectedRow = row;
+    this.activeBreakId = row.breakId;
+    this.hasInlineDetail = true;
     this.state.selectBreak(row.breakItem);
   }
 

--- a/frontend/src/app/components/analyst-workspace/analyst-workspace.component.ts
+++ b/frontend/src/app/components/analyst-workspace/analyst-workspace.component.ts
@@ -59,6 +59,7 @@ export class AnalystWorkspaceComponent implements OnInit, OnDestroy {
   readonly savedViews$ = this.resultState.savedViews$;
   readonly exportJobs$ = this.resultState.exportJobs$;
   readonly activeView$ = this.resultState.activeView$;
+  readonly selectedBreak$ = this.state.selectedBreak$;
   readonly activity$ = this.state.activity$;
   readonly runDetail$ = this.state.runDetail$;
   readonly filterMetadata$ = this.state.filterMetadata$;

--- a/frontend/src/app/components/analyst-workspace/analyst-workspace.component.ts
+++ b/frontend/src/app/components/analyst-workspace/analyst-workspace.component.ts
@@ -15,7 +15,6 @@ import {
   TriggerRunPayload
 } from '../../models/api-models';
 import { ReconciliationListComponent } from '../reconciliation-list/reconciliation-list.component';
-import { BreakDetailComponent } from '../break-detail/break-detail.component';
 import { SystemActivityComponent } from '../system-activity/system-activity.component';
 import { ResultGridComponent } from '../result-grid/result-grid.component';
 import { RunDetailComponent } from '../run-detail/run-detail.component';
@@ -42,7 +41,6 @@ interface ColumnFilterRow {
     FormsModule,
     AsyncPipe,
     ReconciliationListComponent,
-    BreakDetailComponent,
     SystemActivityComponent,
     ResultGridComponent,
     RunDetailComponent,
@@ -61,7 +59,6 @@ export class AnalystWorkspaceComponent implements OnInit, OnDestroy {
   readonly savedViews$ = this.resultState.savedViews$;
   readonly exportJobs$ = this.resultState.exportJobs$;
   readonly activeView$ = this.resultState.activeView$;
-  readonly selectedBreak$ = this.state.selectedBreak$;
   readonly activity$ = this.state.activity$;
   readonly runDetail$ = this.state.runDetail$;
   readonly filterMetadata$ = this.state.filterMetadata$;
@@ -320,6 +317,18 @@ export class AnalystWorkspaceComponent implements OnInit, OnDestroy {
 
   loadMore(): void {
     this.resultState.loadMore();
+  }
+
+  handleAddComment(event: { breakId: number; comment: string; action: string }): void {
+    this.state.addComment(event.breakId, event.comment, event.action);
+  }
+
+  handleUpdateStatus(event: { breakId: number; status: BreakStatus; comment?: string; correlationId?: string }): void {
+    this.state.updateStatus(event.breakId, {
+      status: event.status,
+      comment: event.comment,
+      correlationId: event.correlationId
+    });
   }
 
   handleApplySavedView(view: SavedView): void {

--- a/frontend/src/app/components/break-detail/break-detail.component.css
+++ b/frontend/src/app/components/break-detail/break-detail.component.css
@@ -15,6 +15,11 @@
   color: #0f172a;
 }
 
+.break-detail.compact {
+  padding: 0;
+  gap: 1rem;
+}
+
 .detail-header {
   display: flex;
   justify-content: space-between;
@@ -93,6 +98,11 @@
   font-size: 0.95rem;
 }
 
+.break-detail.compact .workflow-summary {
+  background: rgba(99, 102, 241, 0.08);
+  border-left-color: #4338ca;
+}
+
 .section-card {
   background: #f8fafc;
   border: 1px solid #e2e8f0;
@@ -102,6 +112,12 @@
   flex-direction: column;
   gap: 0.75rem;
   min-width: 0;
+}
+
+.break-detail.compact .section-card {
+  background: #fff;
+  border-color: #dce4f3;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
 }
 
 .section-card h4 {

--- a/frontend/src/app/components/break-detail/break-detail.component.css
+++ b/frontend/src/app/components/break-detail/break-detail.component.css
@@ -5,7 +5,7 @@
   max-width: 100%;
 }
 
-.break-detail {
+.break-detail-view {
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -15,7 +15,7 @@
   color: #0f172a;
 }
 
-.break-detail.compact {
+.break-detail-view.compact {
   padding: 0;
   gap: 1rem;
 }
@@ -44,6 +44,31 @@
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  position: relative;
+}
+
+.status-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #475569;
+  margin-right: 0.4rem;
+}
+
+.status-value {
+  font-weight: 700;
+  color: inherit;
+}
+
+.status-readable {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .status-chip,
@@ -98,7 +123,7 @@
   font-size: 0.95rem;
 }
 
-.break-detail.compact .workflow-summary {
+.break-detail-view.compact .workflow-summary {
   background: rgba(99, 102, 241, 0.08);
   border-left-color: #4338ca;
 }
@@ -114,7 +139,7 @@
   min-width: 0;
 }
 
-.break-detail.compact .section-card {
+.break-detail-view.compact .section-card {
   background: #fff;
   border-color: #dce4f3;
   box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);

--- a/frontend/src/app/components/break-detail/break-detail.component.html
+++ b/frontend/src/app/components/break-detail/break-detail.component.html
@@ -1,11 +1,15 @@
-<section class="break-detail" *ngIf="breakItem as active; else noBreak" [class.compact]="compact">
+<section class="break-detail-view" *ngIf="breakItem as active; else noBreak" [class.compact]="compact">
   <header class="detail-header">
     <div class="title-group">
       <h3>Break {{ active.id }}</h3>
       <p class="detected">Detected {{ active.detectedAt | date: 'short' }}</p>
     </div>
-    <div class="status-group">
-      <span class="status-chip status-{{ active.status | lowercase }}">{{ active.status }}</span>
+    <div class="status-group" role="status" aria-live="polite">
+      <span class="status-chip status-{{ active.status | lowercase }}">
+        <span class="status-label">Status:&nbsp;</span>
+        <span class="status-value">{{ active.status }}</span>
+      </span>
+      <span class="status-readable">Status: {{ active.status }}</span>
       <span class="type-chip">{{ active.breakType }}</span>
     </div>
   </header>

--- a/frontend/src/app/components/break-detail/break-detail.component.html
+++ b/frontend/src/app/components/break-detail/break-detail.component.html
@@ -1,4 +1,4 @@
-<section class="break-detail" *ngIf="breakItem as active; else noBreak">
+<section class="break-detail" *ngIf="breakItem as active; else noBreak" [class.compact]="compact">
   <header class="detail-header">
     <div class="title-group">
       <h3>Break {{ active.id }}</h3>
@@ -14,7 +14,7 @@
     {{ workflowSummary }}
   </div>
 
-  <section class="section-card meta-section">
+  <section class="section-card meta-section" *ngIf="!compact">
     <h4>Classifications & details</h4>
     <div class="meta-grid">
       <div class="meta-item" *ngFor="let entry of classificationEntries">

--- a/frontend/src/app/components/break-detail/break-detail.component.ts
+++ b/frontend/src/app/components/break-detail/break-detail.component.ts
@@ -14,6 +14,7 @@ import { BreakStatus } from '../../models/break-status';
 export class BreakDetailComponent implements OnChanges {
   @Input() breakItem: BreakItem | null = null;
   @Input() workflowSummary: string | null = null;
+  @Input() compact = false;
   @Output() addComment = new EventEmitter<{ breakId: number; comment: string; action: string }>();
   @Output() updateStatus = new EventEmitter<{
     breakId: number;

--- a/frontend/src/app/components/result-grid/result-grid.component.css
+++ b/frontend/src/app/components/result-grid/result-grid.component.css
@@ -270,48 +270,14 @@
 
 .expanded-panel {
   overflow: hidden;
-  padding: 0 1rem 1rem;
-  background: #f9fbff;
+  padding: 1.25rem 1.5rem;
+  background: linear-gradient(180deg, #eef5ff 0%, #f8fbff 100%);
+  border-top: 1px solid #dbe4f3;
 }
 
-.expanded-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1.25rem;
-}
-
-.expanded-column h5 {
-  margin: 1rem 0 0.5rem;
-  font-size: 0.95rem;
-  font-weight: 600;
-  color: #1e293b;
-}
-
-.detail-pair {
-  display: grid;
-  grid-template-columns: minmax(120px, 160px) minmax(0, 1fr);
-  gap: 0.5rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px dashed #e2e8f0;
-}
-
-.detail-pair:last-child {
-  border-bottom: none;
-}
-
-.detail-pair dt {
-  margin: 0;
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: #64748b;
-}
-
-.detail-pair dd {
-  margin: 0;
-  font-size: 0.95rem;
-  color: #0f172a;
-  word-break: break-word;
+.inline-break-detail {
+  display: block;
+  max-width: 100%;
 }
 
 .detail-placeholder {

--- a/frontend/src/app/components/result-grid/result-grid.component.html
+++ b/frontend/src/app/components/result-grid/result-grid.component.html
@@ -142,52 +142,16 @@
       <ng-container matColumnDef="expandedDetail">
         <td mat-cell *matCellDef="let row" [attr.colspan]="columnsWithExpand.length" class="expanded-cell">
           <div class="expanded-panel" [@detailExpand]="row.element === expandedRow ? 'expanded' : 'collapsed'">
-            <div class="expanded-grid">
-              <div class="expanded-column">
-                <h5>Break metadata</h5>
-                <dl>
-                  <div class="detail-pair">
-                    <dt>Break ID</dt>
-                    <dd>{{ row.element.breakId }}</dd>
-                  </div>
-                  <div class="detail-pair">
-                    <dt>Run ID</dt>
-                    <dd>{{ row.element.runId ?? '—' }}</dd>
-                  </div>
-                  <div class="detail-pair">
-                    <dt>Run time</dt>
-                    <dd>{{ row.element.runDateTime || '—' }}</dd>
-                  </div>
-                  <div class="detail-pair">
-                    <dt>Status</dt>
-                    <dd>{{ row.element.breakItem.status }}</dd>
-                  </div>
-                  <div class="detail-pair">
-                    <dt>Trigger</dt>
-                    <dd>{{ row.element.triggerType || '—' }}</dd>
-                  </div>
-                </dl>
-              </div>
-              <div class="expanded-column">
-                <h5>Attributes</h5>
-                <dl>
-                  <ng-container *ngFor="let column of columns">
-                    <ng-container *ngIf="displayAttribute(row.element, column.key) !== '—'">
-                      <div class="detail-pair">
-                        <dt>{{ column.label }}</dt>
-                        <dd>{{ displayAttribute(row.element, column.key) }}</dd>
-                      </div>
-                    </ng-container>
-                  </ng-container>
-                  <ng-container *ngIf="columns.length === 0">
-                    <div class="detail-pair">
-                      <dt>Attributes</dt>
-                      <dd>No additional attributes available.</dd>
-                    </div>
-                  </ng-container>
-                </dl>
-              </div>
-            </div>
+            <ng-container *ngIf="row.element === expandedRow">
+              <urp-break-detail
+                class="inline-break-detail"
+                [breakItem]="row.element.breakItem"
+                [workflowSummary]="workflowSummary"
+                [compact]="true"
+                (addComment)="handleAddComment($event)"
+                (updateStatus)="handleUpdateStatus($event)"
+              ></urp-break-detail>
+            </ng-container>
           </div>
         </td>
       </ng-container>

--- a/frontend/src/app/components/result-grid/result-grid.component.ts
+++ b/frontend/src/app/components/result-grid/result-grid.component.ts
@@ -120,6 +120,16 @@ export class ResultGridComponent implements OnChanges {
       this.selectedIds = new Set(incoming);
     }
 
+    if (changes['selectedRowId']) {
+      const nextId: number | null = changes['selectedRowId'].currentValue ?? null;
+      if (nextId == null) {
+        this.expandedRow = null;
+      } else {
+        const match = this.rows.find((row) => row.breakId === nextId) ?? null;
+        this.expandedRow = match;
+      }
+    }
+
     if (changes['rows'] && !changes['rows'].firstChange) {
       const existingIds = new Set(this.rows.map((row) => row.breakId));
       let removed = false;

--- a/frontend/src/app/components/result-grid/result-grid.component.ts
+++ b/frontend/src/app/components/result-grid/result-grid.component.ts
@@ -10,6 +10,8 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSortModule, Sort } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
 import { BreakResultRow, GridColumn } from '../../models/api-models';
+import { BreakStatus } from '../../models/break-status';
+import { BreakDetailComponent } from '../break-detail/break-detail.component';
 
 interface DetailRow {
   detailRow: true;
@@ -30,7 +32,8 @@ type TableRow = BreakResultRow | DetailRow;
     MatPaginatorModule,
     MatProgressSpinnerModule,
     MatSortModule,
-    MatTableModule
+    MatTableModule,
+    BreakDetailComponent
   ],
   templateUrl: './result-grid.component.html',
   styleUrls: ['./result-grid.component.css'],
@@ -52,11 +55,19 @@ export class ResultGridComponent implements OnChanges {
   @Input() total: number | null = null;
   @Input() selectedRowId: number | null = null;
   @Input() selectedBreakIds: number[] | null = null;
+  @Input() workflowSummary: string | null = null;
 
   @Output() selectRow = new EventEmitter<BreakResultRow>();
   @Output() requestMore = new EventEmitter<void>();
   @Output() selectionChange = new EventEmitter<number[]>();
   @Output() selectFiltered = new EventEmitter<void>();
+  @Output() addComment = new EventEmitter<{ breakId: number; comment: string; action: string }>();
+  @Output() updateStatus = new EventEmitter<{
+    breakId: number;
+    status: BreakStatus;
+    comment?: string;
+    correlationId?: string;
+  }>();
 
   readonly baseColumns: Array<{ key: string; label: string; sortable: boolean }> = [
     { key: 'breakId', label: 'Break ID', sortable: true },
@@ -238,6 +249,14 @@ export class ResultGridComponent implements OnChanges {
 
   select(row: BreakResultRow): void {
     this.selectRow.emit(row);
+  }
+
+  handleAddComment(event: { breakId: number; comment: string; action: string }): void {
+    this.addComment.emit(event);
+  }
+
+  handleUpdateStatus(event: { breakId: number; status: BreakStatus; comment?: string; correlationId?: string }): void {
+    this.updateStatus.emit(event);
   }
 
   displayAttribute(row: BreakResultRow, columnKey: string): string {


### PR DESCRIPTION
## Summary
- move the maker-checker and commentary workflow into the result grid expansion panel and retire the side detail rail
- reuse the break detail component inline with a compact view and apply refreshed styling for inline cards
- modernize workspace buttons with consistent gradients and hover states across tabs, filters, and saved views

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d941ac381c832b833b3fad92fc8813