### PR TITLE
feat: add admin data transformation tooling

### DIFF
--- a/automation/regression/tests/end-to-end.spec.ts
+++ b/automation/regression/tests/end-to-end.spec.ts
@@ -701,7 +701,7 @@ test('reconciliation authoring to maker-checker workflow', async ({ page }) => {
   await primaryGridRow.click();
   let detailSection = page.locator('.break-detail');
   await expect(detailSection).toContainText(`Break ${primaryBreakLabel}`);
-  await expect(detailSection).toContainText('Status: OPEN', { timeout: 30000 });
+  await expect(detailSection).toContainText('OPEN', { timeout: 30000 });
 
   const selectionCheckbox = primaryGridRow.locator('input[type="checkbox"]');
   await selectionCheckbox.check();
@@ -728,7 +728,7 @@ test('reconciliation authoring to maker-checker workflow', async ({ page }) => {
       `Maker bulk submission failed (${bulkMakerResponse.status()} ${bulkMakerResponse.statusText()}): ${parsed}`
     );
   }
-  await expect(detailSection).toContainText('Status: PENDING_APPROVAL', { timeout: 30000 });
+  await expect(primaryGridRow).toContainText('PENDING_APPROVAL', { timeout: 30000 });
 
   await logout(page);
 
@@ -761,8 +761,14 @@ test('reconciliation authoring to maker-checker workflow', async ({ page }) => {
   await expect(checkerReconListItem).toBeVisible();
   await checkerReconListItem.click();
 
+  const checkerGridRows = page.locator('urp-result-grid .data-row');
+  const checkerPrimaryRow = checkerGridRows.filter({ hasText: primaryBreakLabel }).first();
+  await expect(checkerPrimaryRow).toBeVisible({ timeout: 30000 });
+  await expect(checkerPrimaryRow).toContainText('PENDING_APPROVAL', { timeout: 30000 });
+  await checkerPrimaryRow.click();
   detailSection = page.locator('.break-detail');
-  await expect(detailSection).toContainText('Status: PENDING_APPROVAL', { timeout: 30000 });
+  await expect(detailSection).toContainText(`Break ${primaryBreakLabel}`);
+  await expect(detailSection).toContainText(/pending[_ ]approval/i, { timeout: 30000 });
 
   await page.getByRole('button', { name: 'Approvals' }).click();
   const checkerQueue = page.locator('.checker-queue');
@@ -808,7 +814,7 @@ test('reconciliation authoring to maker-checker workflow', async ({ page }) => {
   await expect(reloadedCheckerQueue.locator('tbody tr')).toHaveCount(0, { timeout: 30000 });
   detailSection = page.locator('.break-detail');
   await expect(detailSection).toContainText(`Break ${primaryBreakLabel}`);
-  await expect(detailSection).toContainText('Status: CLOSED', { timeout: 30000 });
+  await expect(detailSection).toContainText(/closed/i, { timeout: 30000 });
 
   const workflowScreenshot = '11-maker-checker.png';
   await page.screenshot({ path: resolveAssetPath(workflowScreenshot), fullPage: true });

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -96,6 +96,11 @@
             <version>${commons-csv.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>3.0.22</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>

--- a/backend/src/main/java/com/universal/reconciliation/controller/RestExceptionHandler.java
+++ b/backend/src/main/java/com/universal/reconciliation/controller/RestExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.universal.reconciliation.controller;
 
+import com.universal.reconciliation.service.transform.TransformationEvaluationException;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.springframework.dao.OptimisticLockingFailureException;
@@ -44,5 +45,11 @@ public class RestExceptionHandler {
     public ResponseEntity<Map<String, String>> handleOptimistic(OptimisticLockingFailureException ex) {
         return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(Map.of("message", "Conflict", "details", ex.getMessage()));
+    }
+
+    @ExceptionHandler(TransformationEvaluationException.class)
+    public ResponseEntity<Map<String, String>> handleTransformation(TransformationEvaluationException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(Map.of("message", "Transformation Error", "details", ex.getMessage()));
     }
 }

--- a/backend/src/main/java/com/universal/reconciliation/controller/admin/AdminTransformationController.java
+++ b/backend/src/main/java/com/universal/reconciliation/controller/admin/AdminTransformationController.java
@@ -1,0 +1,47 @@
+package com.universal.reconciliation.controller.admin;
+
+import com.universal.reconciliation.domain.dto.admin.TransformationPreviewRequest;
+import com.universal.reconciliation.domain.dto.admin.TransformationPreviewResponse;
+import com.universal.reconciliation.domain.dto.admin.TransformationValidationRequest;
+import com.universal.reconciliation.domain.dto.admin.TransformationValidationResponse;
+import com.universal.reconciliation.service.admin.AdminTransformationService;
+import com.universal.reconciliation.service.transform.TransformationEvaluationException;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/transformations")
+@PreAuthorize("hasRole('RECON_ADMIN')")
+public class AdminTransformationController {
+
+    private final AdminTransformationService transformationService;
+
+    public AdminTransformationController(AdminTransformationService transformationService) {
+        this.transformationService = transformationService;
+    }
+
+    @PostMapping("/validate")
+    public TransformationValidationResponse validate(
+            @Valid @RequestBody TransformationValidationRequest request) {
+        return transformationService.validate(request);
+    }
+
+    @PostMapping("/preview")
+    public TransformationPreviewResponse preview(
+            @Valid @RequestBody TransformationPreviewRequest request) {
+        return transformationService.preview(request);
+    }
+
+    @ExceptionHandler(TransformationEvaluationException.class)
+    public ResponseEntity<String> handleEvaluationException(TransformationEvaluationException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+}
+

--- a/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/AdminCanonicalFieldMappingDto.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/AdminCanonicalFieldMappingDto.java
@@ -1,8 +1,11 @@
 package com.universal.reconciliation.domain.dto.admin;
 
+import java.util.List;
+
 /**
  * Mapping metadata linking canonical fields to concrete source columns.
  */
+
 public record AdminCanonicalFieldMappingDto(
         Long id,
         String sourceCode,
@@ -10,5 +13,5 @@ public record AdminCanonicalFieldMappingDto(
         String transformationExpression,
         String defaultValue,
         Integer ordinalPosition,
-        boolean required) {}
-
+        boolean required,
+        List<AdminCanonicalFieldTransformationDto> transformations) {}

--- a/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/AdminCanonicalFieldMappingRequest.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/AdminCanonicalFieldMappingRequest.java
@@ -1,6 +1,7 @@
 package com.universal.reconciliation.domain.dto.admin;
 
 import jakarta.validation.constraints.NotBlank;
+import java.util.List;
 
 /**
  * Request payload describing how a canonical field maps to a source column.
@@ -12,5 +13,5 @@ public record AdminCanonicalFieldMappingRequest(
         String transformationExpression,
         String defaultValue,
         Integer ordinalPosition,
-        boolean required) {}
-
+        boolean required,
+        List<AdminCanonicalFieldTransformationRequest> transformations) {}

--- a/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/AdminCanonicalFieldTransformationDto.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/AdminCanonicalFieldTransformationDto.java
@@ -1,0 +1,15 @@
+package com.universal.reconciliation.domain.dto.admin;
+
+import com.universal.reconciliation.domain.enums.TransformationType;
+
+/**
+ * Represents a persisted transformation rule exposed to admin clients.
+ */
+public record AdminCanonicalFieldTransformationDto(
+        Long id,
+        TransformationType type,
+        String expression,
+        String configuration,
+        Integer displayOrder,
+        boolean active) {}
+

--- a/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/AdminCanonicalFieldTransformationRequest.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/AdminCanonicalFieldTransformationRequest.java
@@ -1,0 +1,16 @@
+package com.universal.reconciliation.domain.dto.admin;
+
+import com.universal.reconciliation.domain.enums.TransformationType;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Request payload supplied by admin UI to describe a transformation rule.
+ */
+public record AdminCanonicalFieldTransformationRequest(
+        Long id,
+        @NotNull TransformationType type,
+        String expression,
+        String configuration,
+        Integer displayOrder,
+        Boolean active) {}
+

--- a/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/AdminReconciliationSchemaDto.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/AdminReconciliationSchemaDto.java
@@ -45,6 +45,14 @@ public record AdminReconciliationSchemaDto(
             String transformationExpression,
             String defaultValue,
             Integer ordinalPosition,
-            boolean required) {}
-}
+            boolean required,
+            List<SchemaFieldTransformationDto> transformations) {}
 
+    public record SchemaFieldTransformationDto(
+            Long id,
+            String type,
+            String expression,
+            String configuration,
+            Integer displayOrder,
+            boolean active) {}
+}

--- a/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/TransformationPreviewRequest.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/TransformationPreviewRequest.java
@@ -1,0 +1,21 @@
+package com.universal.reconciliation.domain.dto.admin;
+
+import com.universal.reconciliation.domain.enums.TransformationType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+
+public record TransformationPreviewRequest(
+        Object value,
+        Map<String, Object> rawRecord,
+        @NotNull List<@Valid PreviewTransformationDto> transformations) {
+
+    public record PreviewTransformationDto(
+            @NotNull TransformationType type,
+            String expression,
+            String configuration,
+            Integer displayOrder,
+            Boolean active) {}
+}
+

--- a/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/TransformationPreviewResponse.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/TransformationPreviewResponse.java
@@ -1,0 +1,4 @@
+package com.universal.reconciliation.domain.dto.admin;
+
+public record TransformationPreviewResponse(Object result) {}
+

--- a/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/TransformationValidationRequest.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/TransformationValidationRequest.java
@@ -1,0 +1,10 @@
+package com.universal.reconciliation.domain.dto.admin;
+
+import com.universal.reconciliation.domain.enums.TransformationType;
+import jakarta.validation.constraints.NotNull;
+
+public record TransformationValidationRequest(
+        @NotNull TransformationType type,
+        String expression,
+        String configuration) {}
+

--- a/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/TransformationValidationResponse.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/TransformationValidationResponse.java
@@ -1,0 +1,4 @@
+package com.universal.reconciliation.domain.dto.admin;
+
+public record TransformationValidationResponse(boolean valid, String message) {}
+

--- a/backend/src/main/java/com/universal/reconciliation/domain/entity/CanonicalFieldMapping.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/entity/CanonicalFieldMapping.java
@@ -1,5 +1,6 @@
 package com.universal.reconciliation.domain.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -8,8 +9,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -56,6 +61,10 @@ public class CanonicalFieldMapping {
 
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt = Instant.now();
+
+    @OneToMany(mappedBy = "mapping", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("displayOrder ASC, id ASC")
+    private Set<CanonicalFieldTransformation> transformations = new LinkedHashSet<>();
 
     public void touch() {
         this.updatedAt = Instant.now();

--- a/backend/src/main/java/com/universal/reconciliation/domain/entity/CanonicalFieldTransformation.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/entity/CanonicalFieldTransformation.java
@@ -1,0 +1,64 @@
+package com.universal.reconciliation.domain.entity;
+
+import com.universal.reconciliation.domain.enums.TransformationType;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Represents a single transformation rule applied to a source column prior to
+ * canonical field normalisation.
+ */
+@Entity
+@Table(name = "canonical_field_transformations")
+@Getter
+@Setter
+public class CanonicalFieldTransformation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "mapping_id", nullable = false)
+    private CanonicalFieldMapping mapping;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private TransformationType type;
+
+    @Column(name = "expression", columnDefinition = "TEXT")
+    private String expression;
+
+    @Column(name = "configuration", columnDefinition = "TEXT")
+    private String configuration;
+
+    @Column(name = "display_order", nullable = false)
+    private Integer displayOrder = 0;
+
+    @Column(name = "active", nullable = false)
+    private boolean active = true;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt = Instant.now();
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt = Instant.now();
+
+    public void touch() {
+        this.updatedAt = Instant.now();
+    }
+}
+

--- a/backend/src/main/java/com/universal/reconciliation/domain/enums/TransformationType.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/enums/TransformationType.java
@@ -1,0 +1,12 @@
+package com.universal.reconciliation.domain.enums;
+
+/**
+ * Enumerates the supported transformation rule families that can be chained
+ * together ahead of canonical value normalisation.
+ */
+public enum TransformationType {
+    GROOVY_SCRIPT,
+    EXCEL_FORMULA,
+    FUNCTION_PIPELINE
+}
+

--- a/backend/src/main/java/com/universal/reconciliation/service/admin/AdminTransformationService.java
+++ b/backend/src/main/java/com/universal/reconciliation/service/admin/AdminTransformationService.java
@@ -1,0 +1,75 @@
+package com.universal.reconciliation.service.admin;
+
+import com.universal.reconciliation.domain.dto.admin.TransformationPreviewRequest;
+import com.universal.reconciliation.domain.dto.admin.TransformationPreviewResponse;
+import com.universal.reconciliation.domain.dto.admin.TransformationValidationRequest;
+import com.universal.reconciliation.domain.dto.admin.TransformationValidationResponse;
+import com.universal.reconciliation.domain.entity.CanonicalFieldMapping;
+import com.universal.reconciliation.domain.entity.CanonicalFieldTransformation;
+import com.universal.reconciliation.service.transform.DataTransformationService;
+import com.universal.reconciliation.service.transform.TransformationEvaluationException;
+import jakarta.validation.Valid;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+public class AdminTransformationService {
+
+    private final DataTransformationService transformationService;
+
+    public AdminTransformationService(DataTransformationService transformationService) {
+        this.transformationService = transformationService;
+    }
+
+    public TransformationValidationResponse validate(@Valid TransformationValidationRequest request) {
+        CanonicalFieldTransformation transformation = new CanonicalFieldTransformation();
+        transformation.setType(request.type());
+        transformation.setExpression(trimToNull(request.expression()));
+        transformation.setConfiguration(trimToNull(request.configuration()));
+        try {
+            transformationService.validate(transformation);
+            return new TransformationValidationResponse(true, "Transformation is valid");
+        } catch (TransformationEvaluationException ex) {
+            return new TransformationValidationResponse(false, ex.getMessage());
+        }
+    }
+
+    public TransformationPreviewResponse preview(@Valid TransformationPreviewRequest request) {
+        CanonicalFieldMapping mapping = new CanonicalFieldMapping();
+        mapping.setTransformations(new LinkedHashSet<>());
+        request.transformations().stream()
+                .sorted((a, b) -> {
+                    Integer left = a.displayOrder() != null ? a.displayOrder() : Integer.MAX_VALUE;
+                    Integer right = b.displayOrder() != null ? b.displayOrder() : Integer.MAX_VALUE;
+                    return left.compareTo(right);
+                })
+                .forEach(transformationDto -> {
+                    CanonicalFieldTransformation transformation = new CanonicalFieldTransformation();
+                    transformation.setMapping(mapping);
+                    transformation.setType(transformationDto.type());
+                    transformation.setExpression(trimToNull(transformationDto.expression()));
+                    transformation.setConfiguration(trimToNull(transformationDto.configuration()));
+                    transformation.setDisplayOrder(transformationDto.displayOrder());
+                    transformation.setActive(transformationDto.active() == null || transformationDto.active());
+                    mapping.getTransformations().add(transformation);
+                });
+        try {
+            Object result = transformationService.applyTransformations(
+                    mapping, request.value(), request.rawRecord() == null ? Map.of() : request.rawRecord());
+            return new TransformationPreviewResponse(result);
+        } catch (TransformationEvaluationException ex) {
+            throw ex;
+        }
+    }
+
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}
+

--- a/backend/src/main/java/com/universal/reconciliation/service/transform/DataTransformationService.java
+++ b/backend/src/main/java/com/universal/reconciliation/service/transform/DataTransformationService.java
@@ -1,0 +1,67 @@
+package com.universal.reconciliation.service.transform;
+
+import com.universal.reconciliation.domain.entity.CanonicalFieldMapping;
+import com.universal.reconciliation.domain.entity.CanonicalFieldTransformation;
+import com.universal.reconciliation.domain.enums.TransformationType;
+import java.util.Comparator;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+
+/**
+ * Central orchestrator used by ingestion flows and preview endpoints to
+ * execute configured transformation rules.
+ */
+@Service
+public class DataTransformationService {
+
+    private final GroovyTransformationEvaluator groovyEvaluator;
+    private final ExcelFormulaTransformationEvaluator excelEvaluator;
+    private final FunctionPipelineTransformationEvaluator pipelineEvaluator;
+
+    public DataTransformationService(
+            GroovyTransformationEvaluator groovyEvaluator,
+            ExcelFormulaTransformationEvaluator excelEvaluator,
+            FunctionPipelineTransformationEvaluator pipelineEvaluator) {
+        this.groovyEvaluator = groovyEvaluator;
+        this.excelEvaluator = excelEvaluator;
+        this.pipelineEvaluator = pipelineEvaluator;
+    }
+
+    public Object applyTransformations(CanonicalFieldMapping mapping, Object value, Map<String, Object> rawRecord) {
+        if (mapping.getTransformations() == null || mapping.getTransformations().isEmpty()) {
+            return value;
+        }
+        Map<String, Object> safeRecord = rawRecord == null ? Map.of() : rawRecord;
+        Object current = value;
+        for (CanonicalFieldTransformation transformation : mapping.getTransformations().stream()
+                .sorted(Comparator.comparing(CanonicalFieldTransformation::getDisplayOrder, Comparator.nullsLast(Integer::compareTo)))
+                .toList()) {
+            if (!transformation.isActive()) {
+                continue;
+            }
+            TransformationType type = transformation.getType();
+            if (type == null) {
+                continue;
+            }
+            current = switch (type) {
+                case GROOVY_SCRIPT -> groovyEvaluator.evaluate(transformation, current, safeRecord);
+                case EXCEL_FORMULA -> excelEvaluator.evaluate(transformation, current, safeRecord);
+                case FUNCTION_PIPELINE -> pipelineEvaluator.evaluate(transformation, current, safeRecord);
+            };
+        }
+        return current;
+    }
+
+    public void validate(CanonicalFieldTransformation transformation) {
+        TransformationType type = transformation.getType();
+        if (type == null) {
+            throw new TransformationEvaluationException("Transformation type is required");
+        }
+        switch (type) {
+            case GROOVY_SCRIPT -> groovyEvaluator.validateExpression(transformation.getExpression());
+            case EXCEL_FORMULA -> excelEvaluator.validateExpression(transformation.getExpression());
+            case FUNCTION_PIPELINE -> pipelineEvaluator.validateConfiguration(transformation.getConfiguration());
+        }
+    }
+}
+

--- a/backend/src/main/java/com/universal/reconciliation/service/transform/ExcelFormulaTransformationEvaluator.java
+++ b/backend/src/main/java/com/universal/reconciliation/service/transform/ExcelFormulaTransformationEvaluator.java
@@ -1,0 +1,130 @@
+package com.universal.reconciliation.service.transform;
+
+import com.universal.reconciliation.domain.entity.CanonicalFieldTransformation;
+import java.io.Closeable;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Locale;
+import java.util.Map;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.CellValue;
+import org.apache.poi.ss.usermodel.FormulaEvaluator;
+import org.apache.poi.ss.usermodel.Name;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Component;
+
+/**
+ * Applies Excel-style formulas using Apache POI so admins can reuse familiar
+ * spreadsheet syntax.
+ */
+@Component
+class ExcelFormulaTransformationEvaluator {
+
+    Object evaluate(CanonicalFieldTransformation transformation, Object currentValue, Map<String, Object> rawRecord) {
+        String expression = transformation.getExpression();
+        if (expression == null || expression.isBlank()) {
+            return currentValue;
+        }
+        String formula = normaliseFormula(expression);
+        try (Workbook workbook = new XSSFWorkbook()) {
+            Row row = workbook.createSheet("Transform").createRow(0);
+
+            Cell valueCell = row.createCell(0);
+            assignCellValue(valueCell, currentValue);
+            defineName(workbook, "VALUE", valueCell);
+
+            int columnIndex = 1;
+            for (Map.Entry<String, Object> entry : rawRecord.entrySet()) {
+                Cell cell = row.createCell(columnIndex);
+                assignCellValue(cell, entry.getValue());
+                defineName(workbook, sanitiseName(entry.getKey()), cell);
+                columnIndex++;
+            }
+
+            Cell formulaCell = row.createCell(columnIndex + 1);
+            formulaCell.setCellFormula(formula);
+
+            FormulaEvaluator evaluator = workbook.getCreationHelper().createFormulaEvaluator();
+            CellValue evaluated = evaluator.evaluate(formulaCell);
+            if (evaluated == null) {
+                return currentValue;
+            }
+            return switch (evaluated.getCellType()) {
+                case NUMERIC -> BigDecimal.valueOf(evaluated.getNumberValue());
+                case BOOLEAN -> evaluated.getBooleanValue();
+                case STRING -> evaluated.getStringValue();
+                case BLANK -> currentValue;
+                default -> evaluated.formatAsString();
+            };
+        } catch (IOException ex) {
+            throw new TransformationEvaluationException("Failed to evaluate Excel formula", ex);
+        } catch (RuntimeException ex) {
+            throw new TransformationEvaluationException(
+                    "Excel formula evaluation failed: " + ex.getMessage(), ex);
+        }
+    }
+
+    void validateExpression(String expression) {
+        if (expression == null || expression.isBlank()) {
+            throw new TransformationEvaluationException("Excel formula cannot be empty");
+        }
+        try (Workbook workbook = new XSSFWorkbook()) {
+            Row row = workbook.createSheet("Validate").createRow(0);
+            Cell valueCell = row.createCell(0);
+            assignCellValue(valueCell, "sample");
+            defineName(workbook, "VALUE", valueCell);
+            Cell formulaCell = row.createCell(1);
+            formulaCell.setCellFormula(normaliseFormula(expression));
+            FormulaEvaluator evaluator = workbook.getCreationHelper().createFormulaEvaluator();
+            evaluator.evaluate(formulaCell);
+        } catch (IOException ex) {
+            throw new TransformationEvaluationException("Unable to validate Excel formula", ex);
+        } catch (RuntimeException ex) {
+            throw new TransformationEvaluationException(
+                    "Excel formula validation failed: " + ex.getMessage(), ex);
+        }
+    }
+
+    private void defineName(Workbook workbook, String name, Cell cell) {
+        Name definedName = workbook.createName();
+        definedName.setNameName(name);
+        definedName.setRefersToFormula(String.format("%s!%s", cell.getSheet().getSheetName(), cell.getAddress().formatAsString()));
+    }
+
+    private void assignCellValue(Cell cell, Object value) {
+        if (value == null) {
+            return;
+        }
+        if (value instanceof Number number) {
+            cell.setCellValue(number.doubleValue());
+        } else if (value instanceof Boolean bool) {
+            cell.setCellValue(bool);
+        } else {
+            cell.setCellValue(value.toString());
+        }
+    }
+
+    private String sanitiseName(String rawName) {
+        if (rawName == null || rawName.isBlank()) {
+            return "_";
+        }
+        String uppercase = rawName.trim().toUpperCase(Locale.ROOT);
+        StringBuilder builder = new StringBuilder();
+        for (char ch : uppercase.toCharArray()) {
+            if (Character.isLetterOrDigit(ch) || ch == '_') {
+                builder.append(ch);
+            } else {
+                builder.append('_');
+            }
+        }
+        return builder.toString();
+    }
+
+    private String normaliseFormula(String formula) {
+        String trimmed = formula.trim();
+        return trimmed.startsWith("=") ? trimmed.substring(1) : trimmed;
+    }
+}

--- a/backend/src/main/java/com/universal/reconciliation/service/transform/FunctionPipelineTransformationEvaluator.java
+++ b/backend/src/main/java/com/universal/reconciliation/service/transform/FunctionPipelineTransformationEvaluator.java
@@ -1,0 +1,156 @@
+package com.universal.reconciliation.service.transform;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.universal.reconciliation.domain.entity.CanonicalFieldTransformation;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Hydrates and executes UI-authored transformation function pipelines.
+ */
+@Component
+class FunctionPipelineTransformationEvaluator {
+
+    private final ObjectMapper objectMapper;
+    private final Map<String, BiFunction<FunctionCallContext, List<String>, Object>> handlers = new HashMap<>();
+
+    FunctionPipelineTransformationEvaluator(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+        registerDefaultHandlers();
+    }
+
+    Object evaluate(CanonicalFieldTransformation transformation, Object currentValue, Map<String, Object> rawRecord) {
+        if (!StringUtils.hasText(transformation.getConfiguration())) {
+            return currentValue;
+        }
+        PipelineDefinition definition = readPipeline(transformation.getConfiguration());
+        if (definition.steps() == null || definition.steps().isEmpty()) {
+            return currentValue;
+        }
+        Object value = currentValue;
+        FunctionCallContext context = new FunctionCallContext(value, rawRecord);
+        for (PipelineStep step : definition.steps()) {
+            BiFunction<FunctionCallContext, List<String>, Object> handler =
+                    handlers.get(step.function().toUpperCase(Locale.ROOT));
+            if (handler == null) {
+                throw new TransformationEvaluationException("Unsupported function: " + step.function());
+            }
+            context = new FunctionCallContext(handler.apply(context, step.args()), rawRecord);
+        }
+        return context.value();
+    }
+
+    void validateConfiguration(String configuration) {
+        readPipeline(configuration);
+    }
+
+    private PipelineDefinition readPipeline(String configuration) {
+        try {
+            return objectMapper.readValue(configuration, PipelineDefinition.class);
+        } catch (Exception ex) {
+            throw new TransformationEvaluationException("Invalid function pipeline configuration", ex);
+        }
+    }
+
+    private void registerDefaultHandlers() {
+        handlers.put("TRIM", (ctx, args) -> {
+            Object value = ctx.value();
+            return value == null ? null : value.toString().trim();
+        });
+        handlers.put("TO_UPPERCASE", (ctx, args) -> ctx.value() == null ? null : ctx.value().toString().toUpperCase(Locale.ROOT));
+        handlers.put("TO_LOWERCASE", (ctx, args) -> ctx.value() == null ? null : ctx.value().toString().toLowerCase(Locale.ROOT));
+        handlers.put("REPLACE", (ctx, args) -> {
+            if (ctx.value() == null) {
+                return null;
+            }
+            if (args.size() < 2) {
+                throw new TransformationEvaluationException("REPLACE requires two arguments");
+            }
+            String target = resolveArg(args.get(0), ctx.rawRecord());
+            String replacement = resolveArg(args.get(1), ctx.rawRecord());
+            return ctx.value().toString().replace(target, replacement);
+        });
+        handlers.put("SUBSTRING", (ctx, args) -> {
+            if (ctx.value() == null) {
+                return null;
+            }
+            if (args.isEmpty()) {
+                throw new TransformationEvaluationException("SUBSTRING requires at least a start index");
+            }
+            try {
+                int start = Integer.parseInt(args.get(0));
+                int end = args.size() > 1 ? Integer.parseInt(args.get(1)) : ctx.value().toString().length();
+                String value = ctx.value().toString();
+                return value.substring(Math.max(0, start), Math.min(value.length(), end));
+            } catch (NumberFormatException ex) {
+                throw new TransformationEvaluationException("SUBSTRING arguments must be numeric", ex);
+            }
+        });
+        handlers.put("DEFAULT_IF_BLANK", (ctx, args) -> {
+            Object value = ctx.value();
+            if (value == null || !StringUtils.hasText(value.toString())) {
+                return args.isEmpty() ? null : resolveArg(args.get(0), ctx.rawRecord());
+            }
+            return value;
+        });
+        handlers.put("PREFIX", (ctx, args) -> {
+            String prefix = args.isEmpty() ? "" : resolveArg(args.get(0), ctx.rawRecord());
+            return prefix + Optional.ofNullable(ctx.value()).map(Object::toString).orElse("");
+        });
+        handlers.put("SUFFIX", (ctx, args) -> {
+            String suffix = args.isEmpty() ? "" : resolveArg(args.get(0), ctx.rawRecord());
+            return Optional.ofNullable(ctx.value()).map(Object::toString).orElse("") + suffix;
+        });
+        handlers.put("FORMAT_DATE", (ctx, args) -> {
+            if (ctx.value() == null) {
+                return null;
+            }
+            if (args.size() < 2) {
+                throw new TransformationEvaluationException("FORMAT_DATE requires source and target patterns");
+            }
+            String sourcePattern = args.get(0);
+            String targetPattern = args.get(1);
+            try {
+                LocalDate parsed = LocalDate.parse(ctx.value().toString(), DateTimeFormatter.ofPattern(sourcePattern));
+                return parsed.format(DateTimeFormatter.ofPattern(targetPattern));
+            } catch (DateTimeParseException ex) {
+                throw new TransformationEvaluationException("Unable to format date: " + ex.getMessage(), ex);
+            }
+        });
+    }
+
+    private String resolveArg(String rawArg, Map<String, Object> rawRecord) {
+        if (rawArg == null) {
+            return null;
+        }
+        if (rawArg.startsWith("{{") && rawArg.endsWith("}}")) {
+            String key = rawArg.substring(2, rawArg.length() - 2);
+            Object value = rawRecord.get(key);
+            return value != null ? value.toString() : null;
+        }
+        return rawArg;
+    }
+
+    private record PipelineDefinition(List<PipelineStep> steps) {}
+
+    private record PipelineStep(String function, List<String> args) {
+        private PipelineStep {
+            if (function == null || function.isBlank()) {
+                throw new TransformationEvaluationException("Function name cannot be empty");
+            }
+            args = args == null ? new ArrayList<>() : List.copyOf(args);
+        }
+    }
+
+    private record FunctionCallContext(Object value, Map<String, Object> rawRecord) {}
+}

--- a/backend/src/main/java/com/universal/reconciliation/service/transform/GroovyTransformationEvaluator.java
+++ b/backend/src/main/java/com/universal/reconciliation/service/transform/GroovyTransformationEvaluator.java
@@ -1,0 +1,93 @@
+package com.universal.reconciliation.service.transform;
+
+import com.universal.reconciliation.domain.entity.CanonicalFieldTransformation;
+import groovy.lang.Binding;
+import groovy.lang.GroovyClassLoader;
+import groovy.lang.Script;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import org.codehaus.groovy.control.CompilerConfiguration;
+import org.codehaus.groovy.control.customizers.SecureASTCustomizer;
+import org.springframework.stereotype.Component;
+
+/**
+ * Compiles and executes Groovy snippets inside a sandboxed class-loader.
+ */
+@Component
+class GroovyTransformationEvaluator {
+
+    private final GroovyClassLoader groovyClassLoader;
+    private final ConcurrentHashMap<String, Class<? extends Script>> compiledScripts = new ConcurrentHashMap<>();
+
+    GroovyTransformationEvaluator() {
+        CompilerConfiguration configuration = new CompilerConfiguration();
+        configuration.addCompilationCustomizers(buildSecurityCustomizer());
+        this.groovyClassLoader = new GroovyClassLoader(Thread.currentThread().getContextClassLoader(), configuration);
+    }
+
+    Object evaluate(CanonicalFieldTransformation transformation, Object currentValue, Map<String, Object> rawRecord) {
+        String scriptBody = transformation.getExpression();
+        if (scriptBody == null || scriptBody.isBlank()) {
+            return currentValue;
+        }
+        try {
+            Class<? extends Script> scriptClass = compiledScripts.computeIfAbsent(scriptBody, this::compileScript);
+            Script script = scriptClass.getDeclaredConstructor().newInstance();
+            Binding binding = new Binding();
+            binding.setVariable("value", currentValue);
+            binding.setVariable("row", rawRecord);
+            binding.setVariable("raw", rawRecord);
+            script.setBinding(binding);
+            Object result = script.run();
+            return result != null ? result : currentValue;
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException ex) {
+            throw new TransformationEvaluationException("Failed to execute Groovy transformation", ex);
+        } catch (TransformationEvaluationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new TransformationEvaluationException("Groovy transformation failed: " + ex.getMessage(), ex);
+        }
+    }
+
+    void validateExpression(String expression) {
+        if (expression == null || expression.isBlank()) {
+            throw new TransformationEvaluationException("Groovy expression cannot be empty");
+        }
+        compiledScripts.computeIfAbsent(expression, this::compileScript);
+    }
+
+    private Class<? extends Script> compileScript(String body) {
+        try {
+            Class<?> scriptClass = groovyClassLoader.parseClass(body);
+            if (!Script.class.isAssignableFrom(scriptClass)) {
+                throw new TransformationEvaluationException("Groovy script must extend Script");
+            }
+            @SuppressWarnings("unchecked")
+            Class<? extends Script> typed = (Class<? extends Script>) scriptClass;
+            return typed;
+        } catch (TransformationEvaluationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new TransformationEvaluationException("Groovy compilation error: " + ex.getMessage(), ex);
+        }
+    }
+
+    private SecureASTCustomizer buildSecurityCustomizer() {
+        SecureASTCustomizer customizer = new SecureASTCustomizer();
+        customizer.setClosuresAllowed(true);
+        customizer.setMethodDefinitionAllowed(false);
+        customizer.setPackageAllowed(false);
+        customizer.setImportsWhitelist(java.util.Collections.emptyList());
+        customizer.setStarImportsWhitelist(java.util.Collections.emptyList());
+        customizer.setStaticImportsWhitelist(java.util.Collections.emptyList());
+        customizer.setStaticStarImportsWhitelist(java.util.Collections.emptyList());
+        customizer.setReceiversClassesWhiteList(java.util.List.of(
+                Object.class,
+                String.class,
+                Number.class,
+                Map.class));
+        return customizer;
+    }
+}

--- a/backend/src/main/java/com/universal/reconciliation/service/transform/TransformationEvaluationException.java
+++ b/backend/src/main/java/com/universal/reconciliation/service/transform/TransformationEvaluationException.java
@@ -1,0 +1,16 @@
+package com.universal.reconciliation.service.transform;
+
+/**
+ * Signals that a transformation rule failed during compilation or evaluation.
+ */
+public class TransformationEvaluationException extends RuntimeException {
+
+    public TransformationEvaluationException(String message) {
+        super(message);
+    }
+
+    public TransformationEvaluationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}
+

--- a/backend/src/test/java/com/universal/reconciliation/service/admin/AdminReconciliationServiceIntegrationTest.java
+++ b/backend/src/test/java/com/universal/reconciliation/service/admin/AdminReconciliationServiceIntegrationTest.java
@@ -188,9 +188,9 @@ class AdminReconciliationServiceIntegrationTest {
                 true,
                 List.of(
                         new AdminCanonicalFieldMappingRequest(
-                                null, "CUSTODY_FEED", "trade_id", null, null, 0, true),
+                                null, "CUSTODY_FEED", "trade_id", null, null, 0, true, List.of()),
                         new AdminCanonicalFieldMappingRequest(
-                                null, "GL_LEDGER", "trade_id", null, null, 0, true)));
+                                null, "GL_LEDGER", "trade_id", null, null, 0, true, List.of())));
 
         AdminCanonicalFieldRequest netAmount = new AdminCanonicalFieldRequest(
                 null,
@@ -206,9 +206,9 @@ class AdminReconciliationServiceIntegrationTest {
                 true,
                 List.of(
                         new AdminCanonicalFieldMappingRequest(
-                                null, "CUSTODY_FEED", "net_amount", null, null, 0, true),
+                                null, "CUSTODY_FEED", "net_amount", null, null, 0, true, List.of()),
                         new AdminCanonicalFieldMappingRequest(
-                                null, "GL_LEDGER", "net_amount", null, null, 0, true)));
+                                null, "GL_LEDGER", "net_amount", null, null, 0, true, List.of())));
 
         AdminCanonicalFieldRequest currency = new AdminCanonicalFieldRequest(
                 null,
@@ -224,9 +224,9 @@ class AdminReconciliationServiceIntegrationTest {
                 true,
                 List.of(
                         new AdminCanonicalFieldMappingRequest(
-                                null, "CUSTODY_FEED", "currency", null, null, 0, true),
+                                null, "CUSTODY_FEED", "currency", null, null, 0, true, List.of()),
                         new AdminCanonicalFieldMappingRequest(
-                                null, "GL_LEDGER", "currency", null, null, 0, true)));
+                                null, "GL_LEDGER", "currency", null, null, 0, true, List.of())));
 
         AdminReportTemplateRequest reportTemplate = new AdminReportTemplateRequest(
                 null,

--- a/backend/src/test/java/com/universal/reconciliation/service/admin/AdminReconciliationValidatorTest.java
+++ b/backend/src/test/java/com/universal/reconciliation/service/admin/AdminReconciliationValidatorTest.java
@@ -104,7 +104,8 @@ class AdminReconciliationValidatorTest {
                 null,
                 2,
                 true,
-                List.of(new AdminCanonicalFieldMappingRequest(null, "CUSTODY", "net_amount", null, null, 1, true)));
+                List.of(new AdminCanonicalFieldMappingRequest(
+                        null, "CUSTODY", "net_amount", null, null, 1, true, List.of())));
 
         AdminReconciliationRequest request = buildRequest(
                 List.of(
@@ -141,7 +142,8 @@ class AdminReconciliationValidatorTest {
                 null,
                 1,
                 true,
-                List.of(new AdminCanonicalFieldMappingRequest(null, "UNKNOWN", "trade_id", null, null, 1, true)));
+                List.of(new AdminCanonicalFieldMappingRequest(
+                        null, "UNKNOWN", "trade_id", null, null, 1, true, List.of())));
 
         AdminReconciliationRequest request = buildRequest(
                 List.of(
@@ -178,7 +180,8 @@ class AdminReconciliationValidatorTest {
                 null,
                 2,
                 true,
-                List.of(new AdminCanonicalFieldMappingRequest(null, "CUSTODY", "net_amount", null, null, 1, true)));
+                List.of(new AdminCanonicalFieldMappingRequest(
+                        null, "CUSTODY", "net_amount", null, null, 1, true, List.of())));
 
         AdminReconciliationRequest request = buildRequest(
                 List.of(
@@ -328,7 +331,7 @@ class AdminReconciliationValidatorTest {
                 true,
                 List.of(
                         new AdminCanonicalFieldMappingRequest(
-                                null, "CUSTODY", "trade_id", null, null, 1, true)));
+                                null, "CUSTODY", "trade_id", null, null, 1, true, List.of())));
     }
 
     private AdminReconciliationRequest buildRequest(
@@ -361,4 +364,3 @@ class AdminReconciliationValidatorTest {
                         null)));
     }
 }
-

--- a/backend/src/test/java/com/universal/reconciliation/service/transform/DataTransformationServiceTest.java
+++ b/backend/src/test/java/com/universal/reconciliation/service/transform/DataTransformationServiceTest.java
@@ -1,0 +1,74 @@
+package com.universal.reconciliation.service.transform;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.universal.reconciliation.domain.entity.CanonicalFieldMapping;
+import com.universal.reconciliation.domain.entity.CanonicalFieldTransformation;
+import com.universal.reconciliation.domain.enums.TransformationType;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DataTransformationServiceTest {
+
+    private DataTransformationService transformationService;
+
+    @BeforeEach
+    void setUp() {
+        transformationService = new DataTransformationService(
+                new GroovyTransformationEvaluator(),
+                new ExcelFormulaTransformationEvaluator(),
+                new FunctionPipelineTransformationEvaluator(new ObjectMapper()));
+    }
+
+    @Test
+    void applyTransformations_executesGroovyScript() {
+        CanonicalFieldMapping mapping = new CanonicalFieldMapping();
+        mapping.setTransformations(new LinkedHashSet<>());
+
+        CanonicalFieldTransformation transformation = new CanonicalFieldTransformation();
+        transformation.setMapping(mapping);
+        transformation.setType(TransformationType.GROOVY_SCRIPT);
+        transformation.setExpression("return value ? value.toString().reverse() : null");
+        transformation.setActive(true);
+        mapping.getTransformations().add(transformation);
+
+        Object result = transformationService.applyTransformations(mapping, "ABC123", Map.of());
+        assertThat(result).isEqualTo("321CBA");
+    }
+
+    @Test
+    void applyTransformations_executesExcelFormula() {
+        CanonicalFieldMapping mapping = new CanonicalFieldMapping();
+        mapping.setTransformations(new LinkedHashSet<>());
+
+        CanonicalFieldTransformation transformation = new CanonicalFieldTransformation();
+        transformation.setMapping(mapping);
+        transformation.setType(TransformationType.EXCEL_FORMULA);
+        transformation.setExpression("=VALUE & RAW_COL");
+        transformation.setActive(true);
+        mapping.getTransformations().add(transformation);
+
+        Object result = transformationService.applyTransformations(mapping, "10", Map.of("raw_col", "-suffix"));
+        assertThat(result).isEqualTo("10-suffix");
+    }
+
+    @Test
+    void applyTransformations_executesFunctionPipeline() {
+        CanonicalFieldMapping mapping = new CanonicalFieldMapping();
+        mapping.setTransformations(new LinkedHashSet<>());
+
+        CanonicalFieldTransformation transformation = new CanonicalFieldTransformation();
+        transformation.setMapping(mapping);
+        transformation.setType(TransformationType.FUNCTION_PIPELINE);
+        transformation.setConfiguration("{\"steps\":[{\"function\":\"TRIM\"},{\"function\":\"TO_UPPERCASE\"}]}");
+        transformation.setActive(true);
+        mapping.getTransformations().add(transformation);
+
+        Object result = transformationService.applyTransformations(mapping, "  hello ", Map.of());
+        assertThat(result).isEqualTo("HELLO");
+    }
+}
+

--- a/docs/wiki/API-Reference.md
+++ b/docs/wiki/API-Reference.md
@@ -363,6 +363,15 @@ _Response `200 OK`_
 | `/api/admin/reconciliations/{id}` | DELETE | Soft-retire a reconciliation definition and hide it from analyst views. |
 | `/api/admin/reconciliations/{id}/schema` | GET | Export canonical schema metadata for ETL teams and automation scripts. |
 | `/api/admin/reconciliations/{id}/sources/{code}/batches` | POST | Upload a source data batch via multipart form-data. Accepts file payload plus adapter metadata. |
+| `/api/admin/transformations/validate` | POST | Validate a single transformation definition (Groovy, Excel formula, or function pipeline) without persisting changes. |
+| `/api/admin/transformations/preview` | POST | Apply one or more transformations to sample data and return the transformed value for UI previews. |
+
+**Transformation helper endpoints**
+
+Use the helper endpoints while authoring transformations in the admin workspace:
+
+- `POST /api/admin/transformations/validate` — body accepts `{ "type": "GROOVY_SCRIPT" | "EXCEL_FORMULA" | "FUNCTION_PIPELINE", "expression": "...", "configuration": "..." }` and returns `{ "valid": true/false, "message": "..." }`.
+- `POST /api/admin/transformations/preview` — body accepts `{ "value": "sample", "rawRecord": { "column": "value" }, "transformations": [{ ... }] }` and responds with `{ "result": "transformed" }`.
 
 **Sample: List reconciliation definitions**
 
@@ -494,8 +503,40 @@ _Response `201 Created`_
       "role": "KEY",
       "formattingHint": null,
       "mappings": [
-        {"sourceCode": "CUSTODY_FEED", "sourceColumn": "trade_id"},
-        {"sourceCode": "GL_LEDGER", "sourceColumn": "trade_id"}
+        {
+          "sourceCode": "CUSTODY_FEED",
+          "sourceColumn": "trade_id",
+          "defaultValue": null,
+          "ordinalPosition": 0,
+          "required": true,
+          "transformations": [
+            {
+              "id": 5001,
+              "type": "FUNCTION_PIPELINE",
+              "expression": null,
+              "configuration": "{\"steps\":[{\"function\":\"TRIM\"},{\"function\":\"TO_UPPERCASE\"}]}",
+              "displayOrder": 0,
+              "active": true
+            }
+          ]
+        },
+        {
+          "sourceCode": "GL_LEDGER",
+          "sourceColumn": "trade_id",
+          "defaultValue": null,
+          "ordinalPosition": 0,
+          "required": true,
+          "transformations": [
+            {
+              "id": 5002,
+              "type": "GROOVY_SCRIPT",
+              "expression": "return value?.trim()",
+              "configuration": null,
+              "displayOrder": 0,
+              "active": true
+            }
+          ]
+        }
       ]
     }
   ]

--- a/docs/wiki/Admin-Configurator-Guide.md
+++ b/docs/wiki/Admin-Configurator-Guide.md
@@ -33,6 +33,11 @@ The **New reconciliation** action launches a six-step wizard:
 3. **Schema** – Define canonical fields, choose roles (e.g., `KEY`, `COMPARE`, `CLASSIFIER`), set
    comparison logic, tolerances, and formatting hints, then map each field to source columns. The
    backend enforces at least one anchor source, unique field names, and key-field presence.
+   - **Transformation rules:** Each mapping can chain transformation rules before values hit the
+     canonical layer. Choose between Groovy scripts (executed in a sandbox), Excel-style formulas, or
+     the function pipeline builder (trim, case conversions, replacements, date formatting, and more).
+     Use the inline validation button to compile scripts and formulas before saving, and leverage the
+     preview panel with sample rows to confirm the final output.
 4. **Reports** – Optional templates for downstream exports. Define column order, highlight settings,
    and whether to include matched/mismatched records.
 5. **Access** – Assign LDAP groups with maker/checker/viewer roles, notification preferences, and

--- a/examples/admin-configurator/payloads/reconciliation.json
+++ b/examples/admin-configurator/payloads/reconciliation.json
@@ -60,7 +60,17 @@
           "transformationExpression": null,
           "defaultValue": null,
           "ordinalPosition": 0,
-          "required": true
+          "required": true,
+          "transformations": [
+            {
+              "id": null,
+              "type": "FUNCTION_PIPELINE",
+              "expression": null,
+              "configuration": "{\"steps\":[{\"function\":\"TRIM\"},{\"function\":\"TO_UPPERCASE\"}]}",
+              "displayOrder": 0,
+              "active": true
+            }
+          ]
         },
         {
           "id": null,
@@ -69,7 +79,17 @@
           "transformationExpression": null,
           "defaultValue": null,
           "ordinalPosition": 0,
-          "required": true
+          "required": true,
+          "transformations": [
+            {
+              "id": null,
+              "type": "GROOVY_SCRIPT",
+              "expression": "return value ? value.toString().trim() : null",
+              "configuration": null,
+              "displayOrder": 0,
+              "active": true
+            }
+          ]
         }
       ]
     },
@@ -93,7 +113,17 @@
           "transformationExpression": null,
           "defaultValue": null,
           "ordinalPosition": 0,
-          "required": true
+          "required": true,
+          "transformations": [
+            {
+              "id": null,
+              "type": "EXCEL_FORMULA",
+              "expression": "=VALUE * 1",
+              "configuration": null,
+              "displayOrder": 0,
+              "active": true
+            }
+          ]
         },
         {
           "id": null,
@@ -102,7 +132,17 @@
           "transformationExpression": null,
           "defaultValue": null,
           "ordinalPosition": 0,
-          "required": true
+          "required": true,
+          "transformations": [
+            {
+              "id": null,
+              "type": "FUNCTION_PIPELINE",
+              "expression": null,
+              "configuration": "{\"steps\":[{\"function\":\"TRIM\"}]}",
+              "displayOrder": 0,
+              "active": true
+            }
+          ]
         }
       ]
     },
@@ -126,7 +166,17 @@
           "transformationExpression": null,
           "defaultValue": null,
           "ordinalPosition": 0,
-          "required": true
+          "required": true,
+          "transformations": [
+            {
+              "id": null,
+              "type": "FUNCTION_PIPELINE",
+              "expression": null,
+              "configuration": "{\"steps\":[{\"function\":\"TRIM\"},{\"function\":\"TO_UPPERCASE\"}]}",
+              "displayOrder": 0,
+              "active": true
+            }
+          ]
         },
         {
           "id": null,
@@ -135,7 +185,17 @@
           "transformationExpression": null,
           "defaultValue": null,
           "ordinalPosition": 0,
-          "required": true
+          "required": true,
+          "transformations": [
+            {
+              "id": null,
+              "type": "FUNCTION_PIPELINE",
+              "expression": null,
+              "configuration": "{\"steps\":[{\"function\":\"TRIM\"}]}",
+              "displayOrder": 0,
+              "active": true
+            }
+          ]
         }
       ]
     }

--- a/frontend/src/app/components/admin/admin-reconciliation-detail.component.css
+++ b/frontend/src/app/components/admin/admin-reconciliation-detail.component.css
@@ -158,6 +158,18 @@
   padding-left: 1.1rem;
 }
 
+.transformation-summary {
+  margin-top: 0.35rem;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.transformation-summary ul {
+  list-style: disc;
+  margin: 0.25rem 0 0;
+  padding-left: 1.1rem;
+}
+
 .reports {
   margin-top: 2rem;
   display: grid;

--- a/frontend/src/app/components/admin/admin-reconciliation-detail.component.html
+++ b/frontend/src/app/components/admin/admin-reconciliation-detail.component.html
@@ -133,6 +133,16 @@
               <li *ngFor="let mapping of field.mappings">
                 <strong>{{ mapping.sourceCode }}</strong>: {{ mapping.sourceColumn }}
                 <span *ngIf="mapping.transformationExpression"> · {{ mapping.transformationExpression }}</span>
+                <div *ngIf="mapping.transformations?.length" class="transformation-summary">
+                  <span>Rules:</span>
+                  <ul>
+                    <li *ngFor="let transformation of mapping.transformations">
+                      {{ transformation.type }}
+                      <span *ngIf="transformation.expression"> · {{ transformation.expression }}</span>
+                      <span *ngIf="transformation.configuration"> · {{ transformation.configuration }}</span>
+                    </li>
+                  </ul>
+                </div>
               </li>
             </ul>
           </td>

--- a/frontend/src/app/components/admin/admin-reconciliation-wizard.component.css
+++ b/frontend/src/app/components/admin/admin-reconciliation-wizard.component.css
@@ -166,12 +166,112 @@
   gap: 0.75rem;
 }
 
-.mapping-row,
+.mapping-row {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 0.75rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  background: #fff;
+}
+
+.mapping-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+  align-items: end;
+}
+
 .column-row {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 0.75rem;
   align-items: end;
+}
+
+.transformation-list {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border: 1px dashed #cbd5f5;
+  border-radius: 6px;
+  background: #f8fafc;
+}
+
+.transformation-card {
+  display: grid;
+  gap: 0.6rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 0.75rem;
+  background: #fff;
+}
+
+.transformation-header {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.transformation-body {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.transformation-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.pipeline-step {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  background: #f1f5f9;
+}
+
+.pipeline-args {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.pipeline-args .arg-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.preview-tools {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  background: #f8fafc;
+}
+
+.preview-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.success {
+  color: #15803d;
+}
+
+.error {
+  color: #dc2626;
+}
+
+.hint {
+  font-size: 0.85rem;
+  color: #64748b;
+  margin: 0;
 }
 
 .report-flags {

--- a/frontend/src/app/components/admin/admin-reconciliation-wizard.component.html
+++ b/frontend/src/app/components/admin/admin-reconciliation-wizard.component.html
@@ -136,13 +136,123 @@
         <div formArrayName="mappings" class="mappings">
           <h4>Mappings</h4>
           <div *ngFor="let mappingGroup of sourceMappings(i).controls; let m = index" [formGroupName]="m" class="mapping-row">
-            <label>Source<input type="text" formControlName="sourceCode" /></label>
-            <label>Column<input type="text" formControlName="sourceColumn" /></label>
-            <label>Transform<input type="text" formControlName="transformationExpression" placeholder="Optional expression" /></label>
-            <label>Default<input type="text" formControlName="defaultValue" /></label>
-            <label>Ordinal<input type="number" formControlName="ordinalPosition" /></label>
-            <label class="checkbox"><input type="checkbox" formControlName="required" /> Required</label>
-            <button type="button" class="link" (click)="removeMapping(i, m)">Remove</button>
+            <div class="mapping-grid">
+              <label>Source<input type="text" formControlName="sourceCode" /></label>
+              <label>Column<input type="text" formControlName="sourceColumn" /></label>
+              <label>Legacy expression
+                <input type="text" formControlName="transformationExpression" placeholder="Optional legacy expression" />
+              </label>
+              <label>Default<input type="text" formControlName="defaultValue" /></label>
+              <label>Ordinal<input type="number" formControlName="ordinalPosition" /></label>
+              <label class="checkbox"><input type="checkbox" formControlName="required" /> Required</label>
+              <button type="button" class="link" (click)="removeMapping(i, m)">Remove mapping</button>
+            </div>
+
+            <div formArrayName="transformations" class="transformation-list">
+              <h5>Transformations</h5>
+              <div
+                *ngFor="let transformationGroup of mappingTransformations(i, m).controls; let t = index"
+                [formGroupName]="t"
+                class="transformation-card"
+              >
+                <div class="transformation-header">
+                  <label>
+                    Type
+                    <select formControlName="type" (change)="onTransformationTypeChange(i, m, t)">
+                      <option *ngFor="let type of transformationTypes" [value]="type">{{ type }}</option>
+                    </select>
+                  </label>
+                  <label>
+                    Display order
+                    <input type="number" formControlName="displayOrder" />
+                  </label>
+                  <label class="checkbox"><input type="checkbox" formControlName="active" /> Active</label>
+                </div>
+
+                <div class="transformation-body">
+                  <ng-container [ngSwitch]="transformationGroup.get('type')?.value">
+                    <div *ngSwitchCase="'GROOVY_SCRIPT'" class="transformation-editor">
+                      <label>Groovy script<textarea formControlName="expression" rows="4" placeholder="return value"></textarea></label>
+                    </div>
+                    <div *ngSwitchCase="'EXCEL_FORMULA'" class="transformation-editor">
+                      <label>Excel formula<input type="text" formControlName="expression" placeholder="=VALUE" /></label>
+                      <p class="hint">Use VALUE or column names (e.g. CASH_AMOUNT) as named references.</p>
+                    </div>
+                    <div *ngSwitchCase="'FUNCTION_PIPELINE'" class="transformation-editor" formArrayName="pipelineSteps">
+                      <div
+                        *ngFor="let stepGroup of pipelineSteps(i, m, t).controls; let s = index"
+                        [formGroupName]="s"
+                        class="pipeline-step"
+                      >
+                        <label>
+                          Function
+                          <select formControlName="function">
+                            <option *ngFor="let fn of pipelineFunctionOptions" [value]="fn.value">{{ fn.label }}</option>
+                          </select>
+                        </label>
+                        <div formArrayName="args" class="pipeline-args">
+                          <div
+                            *ngFor="let argCtrl of pipelineStepArgs(i, m, t, s).controls; let a = index"
+                            class="arg-row"
+                          >
+                            <label>Arg {{ a + 1 }}<input [formControlName]="a" placeholder="Value or {{column}}" /></label>
+                            <button type="button" class="link" (click)="removePipelineArg(i, m, t, s, a)">Remove</button>
+                          </div>
+                          <button type="button" class="secondary" (click)="addPipelineArg(i, m, t, s)">Add argument</button>
+                        </div>
+                        <button
+                          type="button"
+                          class="link"
+                          (click)="removePipelineStep(i, m, t, s)"
+                          *ngIf="pipelineSteps(i, m, t).length > 1"
+                        >
+                          Remove step
+                        </button>
+                      </div>
+                      <button type="button" class="secondary" (click)="addPipelineStep(i, m, t)">Add step</button>
+                    </div>
+                  </ng-container>
+                </div>
+
+                <div class="transformation-actions">
+                  <button type="button" class="secondary" (click)="validateTransformation(i, m, t)">Validate rule</button>
+                  <button type="button" class="link" (click)="removeTransformation(i, m, t)">Remove</button>
+                </div>
+                <p class="hint" *ngIf="transformationGroup.get('validationMessage')?.value">
+                  {{ transformationGroup.get('validationMessage')?.value }}
+                </p>
+              </div>
+              <button type="button" class="secondary" (click)="addTransformation(i, m)">Add transformation</button>
+            </div>
+
+            <div class="preview-tools">
+              <h5>Preview</h5>
+              <label>
+                Sample value
+                <input
+                  type="text"
+                  [value]="previewState[previewKey(i, m)]?.value || ''"
+                  (input)="handlePreviewInput(i, m, 'value', $event)"
+                />
+              </label>
+              <label>
+                Sample row (JSON)
+                <textarea
+                  rows="3"
+                  [value]="previewState[previewKey(i, m)]?.raw || '{}'"
+                  (input)="handlePreviewInput(i, m, 'raw', $event)"
+                ></textarea>
+              </label>
+              <div class="preview-actions">
+                <button type="button" class="secondary" (click)="previewMapping(i, m)">Preview transformations</button>
+              </div>
+              <p class="success" *ngIf="previewState[previewKey(i, m)]?.result">
+                Result: {{ previewState[previewKey(i, m)]?.result }}
+              </p>
+              <p class="error" *ngIf="previewState[previewKey(i, m)]?.error">
+                {{ previewState[previewKey(i, m)]?.error }}
+              </p>
+            </div>
           </div>
           <button type="button" class="secondary" (click)="addMapping(i)">Add mapping</button>
         </div>

--- a/frontend/src/app/models/admin-api-models.ts
+++ b/frontend/src/app/models/admin-api-models.ts
@@ -29,6 +29,8 @@ export type AccessRole = 'VIEWER' | 'MAKER' | 'CHECKER';
 
 export type DataBatchStatus = 'PENDING' | 'LOADING' | 'COMPLETE' | 'FAILED' | 'ARCHIVED';
 
+export type TransformationType = 'GROOVY_SCRIPT' | 'EXCEL_FORMULA' | 'FUNCTION_PIPELINE';
+
 export interface AdminReconciliationSummary {
   id: number;
   code: string;
@@ -73,6 +75,16 @@ export interface AdminCanonicalFieldMapping {
   defaultValue?: string | null;
   ordinalPosition?: number | null;
   required: boolean;
+  transformations: AdminCanonicalFieldTransformation[];
+}
+
+export interface AdminCanonicalFieldTransformation {
+  id?: number | null;
+  type: TransformationType;
+  expression?: string | null;
+  configuration?: string | null;
+  displayOrder?: number | null;
+  active: boolean;
 }
 
 export interface AdminCanonicalField {
@@ -203,7 +215,15 @@ export interface AdminReconciliationSchema {
     thresholdPercentage?: number | null;
     formattingHint?: string | null;
     required: boolean;
-    mappings: AdminCanonicalFieldMapping[];
+    mappings: {
+      sourceCode: string;
+      sourceColumn: string;
+      transformationExpression?: string | null;
+      defaultValue?: string | null;
+      ordinalPosition?: number | null;
+      required: boolean;
+      transformations: SchemaFieldTransformation[];
+    }[];
   }[];
 }
 
@@ -211,4 +231,42 @@ export interface AdminIngestionRequestMetadata {
   adapterType: IngestionAdapterType;
   options?: Record<string, unknown>;
   label?: string;
+}
+
+export interface SchemaFieldTransformation {
+  id?: number | null;
+  type: TransformationType;
+  expression?: string | null;
+  configuration?: string | null;
+  displayOrder?: number | null;
+  active: boolean;
+}
+
+export interface TransformationValidationRequest {
+  type: TransformationType;
+  expression?: string | null;
+  configuration?: string | null;
+}
+
+export interface TransformationValidationResponse {
+  valid: boolean;
+  message: string;
+}
+
+export interface PreviewTransformationDto {
+  type: TransformationType;
+  expression?: string | null;
+  configuration?: string | null;
+  displayOrder?: number | null;
+  active?: boolean;
+}
+
+export interface TransformationPreviewRequest {
+  value: unknown;
+  rawRecord: Record<string, unknown>;
+  transformations: PreviewTransformationDto[];
+}
+
+export interface TransformationPreviewResponse {
+  result: unknown;
 }

--- a/frontend/src/app/services/admin-reconciliation-state.service.ts
+++ b/frontend/src/app/services/admin-reconciliation-state.service.ts
@@ -8,7 +8,11 @@ import {
   AdminReconciliationRequest,
   AdminReconciliationSchema,
   AdminReconciliationSummary,
-  ReconciliationLifecycleStatus
+  ReconciliationLifecycleStatus,
+  TransformationValidationRequest,
+  TransformationValidationResponse,
+  TransformationPreviewRequest,
+  TransformationPreviewResponse
 } from '../models/admin-api-models';
 import { ApiService } from './api.service';
 import { NotificationService } from './notification.service';
@@ -230,6 +234,18 @@ export class AdminReconciliationStateService {
         })
       )
       .subscribe();
+  }
+
+  validateTransformation(
+    payload: TransformationValidationRequest
+  ): Observable<TransformationValidationResponse> {
+    return this.api.validateTransformation(payload);
+  }
+
+  previewTransformation(
+    payload: TransformationPreviewRequest
+  ): Observable<TransformationPreviewResponse> {
+    return this.api.previewTransformation(payload);
   }
 
   private refreshSummaries(): void {

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -28,6 +28,10 @@ import {
   AdminReconciliationRequest,
   AdminReconciliationSchema,
   AdminReconciliationSummaryPage,
+  TransformationPreviewRequest,
+  TransformationPreviewResponse,
+  TransformationValidationRequest,
+  TransformationValidationResponse,
   ReconciliationLifecycleStatus
 } from '../models/admin-api-models';
 
@@ -234,6 +238,24 @@ export class ApiService {
     return this.http.post<AdminIngestionBatch>(
       `${BASE_URL}/admin/reconciliations/${definitionId}/sources/${encodeURIComponent(sourceCode)}/batches`,
       formData
+    );
+  }
+
+  validateTransformation(
+    payload: TransformationValidationRequest
+  ): Observable<TransformationValidationResponse> {
+    return this.http.post<TransformationValidationResponse>(
+      `${BASE_URL}/admin/transformations/validate`,
+      payload
+    );
+  }
+
+  previewTransformation(
+    payload: TransformationPreviewRequest
+  ): Observable<TransformationPreviewResponse> {
+    return this.http.post<TransformationPreviewResponse>(
+      `${BASE_URL}/admin/transformations/preview`,
+      payload
     );
   }
 


### PR DESCRIPTION
## Summary
- add transformation REST surface, persistence, and evaluators for groovy, formula, and pipeline rules
- extend admin configurator to author, validate, and preview per-source transformations
- update docs, example payloads, and automation coverage for the maker-checker flow

## Testing
- ./mvnw -B test
- npm test -- --watch=false --browsers=ChromeHeadless
- npm test (automation/regression)
- examples/integration-harness/scripts/run_multi_example_e2e.sh
- ./scripts/local-dev.sh bootstrap
- ./scripts/local-dev.sh seed
- ./scripts/seed-historical.sh
- ./scripts/verify-historical-seed.sh --days 3 --runs-per-day 1 --skip-export-check