### PR TITLE
feat: add admin sample file transformation preview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,6 @@ Welcome, automated contributor! Follow these ground rules to collaborate effecti
 ## Quality Gates
 - **Backend tests:** `cd backend && ./mvnw test`
 - **Frontend tests:** `cd frontend && npm test -- --watch=false --browsers=ChromeHeadless`
-- **Frontend lint (optional):** `cd frontend && npm run lint`
 - **Automation smoke (Playwright):** `cd automation/regression && npm install && npm test`
 - **Examples integration harness:** `examples/integration-harness/scripts/run_multi_example_e2e.sh`
 - **Bootstrap scripts:** `./scripts/local-dev.sh bootstrap` (and `seed` once the stack is running) to confirm local helpers stay healthy.

--- a/automation/regression/tests/fixtures/groovy_preview_sample.csv
+++ b/automation/regression/tests/fixtures/groovy_preview_sample.csv
@@ -1,0 +1,4 @@
+transactionId,amount,currency
+T-1001,105.25,USD
+T-1002,59.50,USD
+T-1003,75.00,EUR

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -106,6 +106,10 @@
             <version>2.9.1</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy</artifactId>
             <version>3.0.22</version>

--- a/backend/src/main/java/com/universal/reconciliation/controller/admin/AdminTransformationController.java
+++ b/backend/src/main/java/com/universal/reconciliation/controller/admin/AdminTransformationController.java
@@ -2,6 +2,8 @@ package com.universal.reconciliation.controller.admin;
 
 import com.universal.reconciliation.domain.dto.admin.GroovyScriptTestRequest;
 import com.universal.reconciliation.domain.dto.admin.GroovyScriptTestResponse;
+import com.universal.reconciliation.domain.dto.admin.TransformationFilePreviewResponse;
+import com.universal.reconciliation.domain.dto.admin.TransformationFilePreviewUploadRequest;
 import com.universal.reconciliation.domain.dto.admin.TransformationPreviewRequest;
 import com.universal.reconciliation.domain.dto.admin.TransformationPreviewResponse;
 import com.universal.reconciliation.domain.dto.admin.TransformationSampleResponse;
@@ -17,9 +19,11 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/admin/transformations")
@@ -42,6 +46,13 @@ public class AdminTransformationController {
     public TransformationPreviewResponse preview(
             @Valid @RequestBody TransformationPreviewRequest request) {
         return transformationService.preview(request);
+    }
+
+    @PostMapping(value = "/preview/upload", consumes = {"multipart/form-data"})
+    public TransformationFilePreviewResponse previewFromFile(
+            @Valid @RequestPart("request") TransformationFilePreviewUploadRequest request,
+            @RequestPart("file") MultipartFile file) {
+        return transformationService.previewFromSampleFile(request, file);
     }
 
     @PostMapping("/groovy/test")

--- a/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/TransformationFilePreviewResponse.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/TransformationFilePreviewResponse.java
@@ -1,0 +1,14 @@
+package com.universal.reconciliation.domain.dto.admin;
+
+import java.util.List;
+import java.util.Map;
+
+public record TransformationFilePreviewResponse(List<Row> rows) {
+
+    public record Row(
+            int rowNumber,
+            Map<String, Object> rawRecord,
+            Object valueBefore,
+            Object transformedValue,
+            String error) {}
+}

--- a/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/TransformationFilePreviewUploadRequest.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/TransformationFilePreviewUploadRequest.java
@@ -1,0 +1,18 @@
+package com.universal.reconciliation.domain.dto.admin;
+
+import com.universal.reconciliation.domain.enums.TransformationSampleFileType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record TransformationFilePreviewUploadRequest(
+        @NotNull TransformationSampleFileType fileType,
+        boolean hasHeader,
+        String delimiter,
+        String sheetName,
+        String recordPath,
+        String valueColumn,
+        String encoding,
+        Integer limit,
+        @NotNull @NotEmpty @Valid List<TransformationPreviewRequest.PreviewTransformationDto> transformations) {}

--- a/backend/src/main/java/com/universal/reconciliation/domain/enums/TransformationSampleFileType.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/enums/TransformationSampleFileType.java
@@ -1,0 +1,13 @@
+package com.universal.reconciliation.domain.enums;
+
+/**
+ * Describes the file formats administrators can upload when previewing
+ * transformations directly from sample data.
+ */
+public enum TransformationSampleFileType {
+    CSV,
+    EXCEL,
+    JSON,
+    XML,
+    DELIMITED
+}

--- a/backend/src/main/java/com/universal/reconciliation/service/transform/TransformationSampleFileService.java
+++ b/backend/src/main/java/com/universal/reconciliation/service/transform/TransformationSampleFileService.java
@@ -1,0 +1,381 @@
+package com.universal.reconciliation.service.transform;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.universal.reconciliation.domain.dto.admin.TransformationFilePreviewUploadRequest;
+import com.universal.reconciliation.domain.enums.TransformationSampleFileType;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.DataFormatter;
+import org.apache.poi.ss.usermodel.FormulaEvaluator;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * Parses ad-hoc sample files uploaded by administrators so they can preview
+ * transformation behaviour without ingesting a full batch first.
+ */
+@Service
+public class TransformationSampleFileService {
+
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+    private static final Pattern PATH_SEGMENT_PATTERN = Pattern.compile("(?<key>[^\\[]+)?(?:\\[(?<index>\\d+)\\])?");
+    private static final int MAX_RECORDS = 10;
+    static final long MAX_UPLOAD_BYTES = 2L * 1024 * 1024; // 2 MiB
+
+    private final ObjectMapper objectMapper;
+    private final XmlMapper xmlMapper;
+
+    public TransformationSampleFileService(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+        this.xmlMapper = XmlMapper.builder()
+                .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+                .build();
+    }
+
+    public List<Map<String, Object>> parseSamples(
+            TransformationFilePreviewUploadRequest request, MultipartFile file) {
+        Objects.requireNonNull(file, "Sample file is required");
+        enforceUploadSize(file);
+
+        int limit = Math.min(Math.max(Optional.ofNullable(request.limit()).orElse(MAX_RECORDS), 1), MAX_RECORDS);
+        TransformationSampleFileType fileType = request.fileType();
+        if (fileType == null) {
+            throw new TransformationEvaluationException("File type is required for sample preview");
+        }
+        return switch (fileType) {
+            case CSV -> parseDelimitedFile(file, request, limit, ',');
+            case DELIMITED -> parseDelimitedFile(file, request, limit, '\t');
+            case EXCEL -> parseExcelFile(file, request, limit);
+            case JSON -> parseJsonFile(file, request, limit);
+            case XML -> parseXmlFile(file, request, limit);
+        };
+    }
+
+    private void enforceUploadSize(MultipartFile file) {
+        long size = file.getSize();
+        if (size > MAX_UPLOAD_BYTES) {
+            throw new TransformationEvaluationException(
+                    "Sample file exceeds the 2 MiB upload limit. Provide a smaller extract.");
+        }
+    }
+
+    private List<Map<String, Object>> parseDelimitedFile(
+            MultipartFile file, TransformationFilePreviewUploadRequest request, int limit, char defaultDelimiter) {
+        char delimiter = resolveDelimiter(request.delimiter(), defaultDelimiter);
+        Charset charset = resolveCharset(request.encoding());
+        boolean hasHeader = request.hasHeader();
+        CSVFormat.Builder builder = CSVFormat.DEFAULT.builder()
+                .setTrim(true)
+                .setIgnoreEmptyLines(true)
+                .setDelimiter(delimiter);
+        if (hasHeader) {
+            builder.setHeader();
+            builder.setSkipHeaderRecord(true);
+        }
+        CSVFormat format = builder.build();
+        try (Reader reader = new InputStreamReader(file.getInputStream(), charset);
+                CSVParser parser = new CSVParser(reader, format)) {
+            List<Map<String, Object>> rows = new ArrayList<>();
+            List<String> headers = new ArrayList<>();
+            if (hasHeader) {
+                headers.addAll(parser.getHeaderNames());
+                if (headers.isEmpty()) {
+                    throw new TransformationEvaluationException(
+                            "Header row was expected but none was found in the sample file.");
+                }
+            }
+            int processed = 0;
+            for (CSVRecord record : parser) {
+                if (!hasHeader && headers.isEmpty()) {
+                    headers = generateColumnHeaders(record.size());
+                } else {
+                    expandHeaders(headers, record.size());
+                }
+                Map<String, Object> row = new LinkedHashMap<>();
+                for (int index = 0; index < headers.size() && index < record.size(); index++) {
+                    row.put(headers.get(index), record.get(index));
+                }
+                if (!row.isEmpty()) {
+                    rows.add(row);
+                    processed++;
+                }
+                if (processed >= limit) {
+                    break;
+                }
+            }
+            return rows;
+        } catch (IOException ex) {
+            throw new TransformationEvaluationException("Failed to read delimited sample file", ex);
+        }
+    }
+
+    private List<Map<String, Object>> parseExcelFile(
+            MultipartFile file, TransformationFilePreviewUploadRequest request, int limit) {
+        boolean hasHeader = request.hasHeader();
+        try (InputStream inputStream = file.getInputStream(); Workbook workbook = WorkbookFactory.create(inputStream)) {
+            Sheet sheet = resolveSheet(workbook, request.sheetName());
+            if (sheet == null) {
+                throw new TransformationEvaluationException("Unable to locate the requested sheet in the workbook");
+            }
+            DataFormatter formatter = new DataFormatter(Locale.ENGLISH);
+            FormulaEvaluator evaluator = workbook.getCreationHelper().createFormulaEvaluator();
+            List<Map<String, Object>> rows = new ArrayList<>();
+            List<String> headers = new ArrayList<>();
+            int processed = 0;
+            Iterator<Row> iterator = sheet.iterator();
+            while (iterator.hasNext()) {
+                Row current = iterator.next();
+                if (current == null) {
+                    continue;
+                }
+                if (hasHeader && headers.isEmpty()) {
+                    headers = extractExcelHeaders(current, formatter, evaluator);
+                    continue;
+                }
+                if (!hasHeader && headers.isEmpty()) {
+                    headers = generateColumnHeaders(detectExcelColumnCount(current));
+                } else {
+                    expandHeaders(headers, detectExcelColumnCount(current));
+                }
+                Map<String, Object> row = new LinkedHashMap<>();
+                for (int i = 0; i < headers.size(); i++) {
+                    Cell cell = current.getCell(i, Row.MissingCellPolicy.RETURN_BLANK_AS_NULL);
+                    if (cell == null) {
+                        continue;
+                    }
+                    row.put(headers.get(i), readExcelCell(cell, formatter, evaluator));
+                }
+                if (!row.isEmpty()) {
+                    rows.add(row);
+                    processed++;
+                }
+                if (processed >= limit) {
+                    break;
+                }
+            }
+            return rows;
+        } catch (IOException ex) {
+            throw new TransformationEvaluationException("Failed to read Excel sample file", ex);
+        }
+    }
+
+    private List<Map<String, Object>> parseJsonFile(
+            MultipartFile file, TransformationFilePreviewUploadRequest request, int limit) {
+        JsonNode root = readJsonTree(file, request.encoding());
+        JsonNode target = resolvePath(root, request.recordPath());
+        List<Map<String, Object>> rows = new ArrayList<>();
+        if (target == null || target.isMissingNode() || target.isNull()) {
+            throw new TransformationEvaluationException("No JSON data found at the provided record path.");
+        }
+        Iterable<JsonNode> sources = target.isArray() ? target : List.of(target);
+        int processed = 0;
+        for (JsonNode node : sources) {
+            if (node == null || node.isNull()) {
+                continue;
+            }
+            rows.add(objectMapper.convertValue(node, MAP_TYPE));
+            processed++;
+            if (processed >= limit) {
+                break;
+            }
+        }
+        return rows;
+    }
+
+    private List<Map<String, Object>> parseXmlFile(
+            MultipartFile file, TransformationFilePreviewUploadRequest request, int limit) {
+        JsonNode root = readXmlTree(file, request.encoding());
+        JsonNode target = resolvePath(root, request.recordPath());
+        if (target == null || target.isMissingNode() || target.isNull()) {
+            throw new TransformationEvaluationException("No XML data found at the provided record path.");
+        }
+        List<Map<String, Object>> rows = new ArrayList<>();
+        Iterable<JsonNode> sources = target.isArray() ? target : List.of(target);
+        int processed = 0;
+        for (JsonNode node : sources) {
+            if (node == null || node.isNull()) {
+                continue;
+            }
+            rows.add(objectMapper.convertValue(node, MAP_TYPE));
+            processed++;
+            if (processed >= limit) {
+                break;
+            }
+        }
+        return rows;
+    }
+
+    private Charset resolveCharset(String encoding) {
+        if (!StringUtils.hasText(encoding)) {
+            return StandardCharsets.UTF_8;
+        }
+        try {
+            return Charset.forName(encoding);
+        } catch (Exception ex) {
+            throw new TransformationEvaluationException("Unsupported character encoding: " + encoding, ex);
+        }
+    }
+
+    private char resolveDelimiter(String delimiter, char defaultDelimiter) {
+        if (!StringUtils.hasLength(delimiter)) {
+            return defaultDelimiter;
+        }
+        return delimiter.charAt(0);
+    }
+
+    private List<String> generateColumnHeaders(int count) {
+        List<String> headers = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            headers.add("COLUMN_" + (i + 1));
+        }
+        return headers;
+    }
+
+    private void expandHeaders(List<String> headers, int desiredSize) {
+        if (headers == null) {
+            return;
+        }
+        int target = Math.max(desiredSize, headers.size());
+        while (headers.size() < target) {
+            headers.add("COLUMN_" + (headers.size() + 1));
+        }
+    }
+
+    private List<String> extractExcelHeaders(Row row, DataFormatter formatter, FormulaEvaluator evaluator) {
+        List<String> headers = new ArrayList<>();
+        int columnCount = detectExcelColumnCount(row);
+        for (int i = 0; i < columnCount; i++) {
+            Cell cell = row.getCell(i, Row.MissingCellPolicy.RETURN_BLANK_AS_NULL);
+            if (cell == null) {
+                headers.add("COLUMN_" + (i + 1));
+            } else {
+                String header = formatter.formatCellValue(cell, evaluator);
+                headers.add(StringUtils.hasText(header) ? header : "COLUMN_" + (i + 1));
+            }
+        }
+        return headers;
+    }
+
+    private Object readExcelCell(Cell cell, DataFormatter formatter, FormulaEvaluator evaluator) {
+        Cell evaluated = evaluator.evaluateInCell(cell);
+        CellType type = evaluated.getCellType();
+        return switch (type) {
+            case BOOLEAN -> evaluated.getBooleanCellValue();
+            case NUMERIC -> org.apache.poi.ss.usermodel.DateUtil.isCellDateFormatted(evaluated)
+                    ? evaluated.getLocalDateTimeCellValue()
+                    : evaluated.getNumericCellValue();
+            case STRING -> evaluated.getStringCellValue();
+            case BLANK -> null;
+            case ERROR -> null;
+            case FORMULA -> formatter.formatCellValue(evaluated, evaluator);
+            default -> formatter.formatCellValue(evaluated, evaluator);
+        };
+    }
+
+    private Sheet resolveSheet(Workbook workbook, String sheetName) {
+        if (StringUtils.hasText(sheetName)) {
+            return workbook.getSheet(sheetName);
+        }
+        return workbook.getNumberOfSheets() > 0 ? workbook.getSheetAt(0) : null;
+    }
+
+    private int detectExcelColumnCount(Row row) {
+        if (row == null) {
+            return 0;
+        }
+        int lastCell = row.getLastCellNum();
+        if (lastCell < 0) {
+            lastCell = 0;
+        }
+        int physical = row.getPhysicalNumberOfCells();
+        return Math.max(lastCell, physical);
+    }
+
+    private JsonNode readJsonTree(MultipartFile file, String encoding) {
+        try {
+            byte[] bytes = file.getBytes();
+            String payload = new String(bytes, resolveCharset(encoding));
+            return objectMapper.readTree(payload);
+        } catch (IOException ex) {
+            throw new TransformationEvaluationException("Failed to parse JSON sample payload", ex);
+        }
+    }
+
+    private JsonNode readXmlTree(MultipartFile file, String encoding) {
+        try {
+            byte[] bytes = file.getBytes();
+            String payload = new String(bytes, resolveCharset(encoding));
+            return xmlMapper.readTree(payload);
+        } catch (IOException ex) {
+            throw new TransformationEvaluationException("Failed to parse XML sample payload", ex);
+        }
+    }
+
+    private JsonNode resolvePath(JsonNode root, String rawPath) {
+        if (root == null) {
+            return null;
+        }
+        if (!StringUtils.hasText(rawPath)) {
+            return root;
+        }
+        JsonNode current = root;
+        String[] segments = rawPath.split("\\.");
+        for (String segment : segments) {
+            if (!StringUtils.hasText(segment)) {
+                continue;
+            }
+            Matcher matcher = PATH_SEGMENT_PATTERN.matcher(segment);
+            JsonNode next = current;
+            while (matcher.find()) {
+                String key = matcher.group("key");
+                String index = matcher.group("index");
+                if (StringUtils.hasText(key)) {
+                    next = next.get(key);
+                    if (next == null || next.isMissingNode()) {
+                        return null;
+                    }
+                }
+                if (StringUtils.hasText(index)) {
+                    int idx = Integer.parseInt(index);
+                    if (!next.isArray() || idx >= next.size()) {
+                        return null;
+                    }
+                    next = next.get(idx);
+                }
+            }
+            if (next == null) {
+                return null;
+            }
+            current = next;
+        }
+        return current;
+    }
+}

--- a/backend/src/test/java/com/universal/reconciliation/controller/harness/HarnessDebugControllerTest.java
+++ b/backend/src/test/java/com/universal/reconciliation/controller/harness/HarnessDebugControllerTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -59,7 +60,9 @@ class HarnessDebugControllerTest {
     void setUp() {
         HarnessDebugController controller =
                 new HarnessDebugController(breakItemRepository, breakAccessService, userContext, breakService);
-        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setMessageConverters(new MappingJackson2HttpMessageConverter())
+                .build();
 
         definition = new ReconciliationDefinition();
         definition.setId(42L);
@@ -163,4 +166,3 @@ class HarnessDebugControllerTest {
                 .andExpect(jsonPath("$.message").value("Not allowed"));
     }
 }
-

--- a/backend/src/test/java/com/universal/reconciliation/service/transform/TransformationSampleFileServiceTest.java
+++ b/backend/src/test/java/com/universal/reconciliation/service/transform/TransformationSampleFileServiceTest.java
@@ -1,0 +1,115 @@
+package com.universal.reconciliation.service.transform;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.universal.reconciliation.domain.dto.admin.TransformationFilePreviewUploadRequest;
+import com.universal.reconciliation.domain.dto.admin.TransformationPreviewRequest;
+import com.universal.reconciliation.domain.enums.TransformationSampleFileType;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+class TransformationSampleFileServiceTest {
+
+    private final TransformationSampleFileService service = new TransformationSampleFileService(new ObjectMapper());
+
+    @Test
+    void parsesCsvWithHeader() {
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "sample.csv",
+                "text/csv",
+                "Amount,Fee\n100,10\n200,20".getBytes(StandardCharsets.UTF_8));
+        TransformationFilePreviewUploadRequest request = new TransformationFilePreviewUploadRequest(
+                TransformationSampleFileType.CSV,
+                true,
+                ",",
+                null,
+                null,
+                "Amount",
+                null,
+                null,
+                List.of(new TransformationPreviewRequest.PreviewTransformationDto(null, null, null, 1, true)));
+
+        List<Map<String, Object>> rows = service.parseSamples(request, file);
+
+        assertThat(rows).hasSize(2);
+        assertThat(rows.get(0)).containsEntry("Amount", "100");
+    }
+
+    @Test
+    void assignsSyntheticHeadersWhenMissing() {
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "sample.csv",
+                "text/csv",
+                "100|OK\n200|FAIL".getBytes(StandardCharsets.UTF_8));
+        TransformationFilePreviewUploadRequest request = new TransformationFilePreviewUploadRequest(
+                TransformationSampleFileType.DELIMITED,
+                false,
+                "|",
+                null,
+                null,
+                "COLUMN_1",
+                null,
+                null,
+                List.of(new TransformationPreviewRequest.PreviewTransformationDto(null, null, null, 1, true)));
+
+        List<Map<String, Object>> rows = service.parseSamples(request, file);
+
+        assertThat(rows.get(0)).containsEntry("COLUMN_1", "100");
+        assertThat(rows.get(0)).containsEntry("COLUMN_2", "OK");
+    }
+
+    @Test
+    void parsesJsonUsingRecordPath() {
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "sample.json",
+                "application/json",
+                "{\"data\":{\"items\":[{\"amount\":100},{\"amount\":200}]}}".getBytes(StandardCharsets.UTF_8));
+        TransformationFilePreviewUploadRequest request = new TransformationFilePreviewUploadRequest(
+                TransformationSampleFileType.JSON,
+                false,
+                null,
+                null,
+                "data.items",
+                "amount",
+                null,
+                null,
+                List.of(new TransformationPreviewRequest.PreviewTransformationDto(null, null, null, 1, true)));
+
+        List<Map<String, Object>> rows = service.parseSamples(request, file);
+
+        assertThat(rows).hasSize(2);
+        assertThat(rows.get(1)).containsEntry("amount", 200);
+    }
+
+    @Test
+    void enforcesUploadSizeLimit() {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.getSize()).thenReturn(TransformationSampleFileService.MAX_UPLOAD_BYTES + 1);
+
+        TransformationFilePreviewUploadRequest request = new TransformationFilePreviewUploadRequest(
+                TransformationSampleFileType.JSON,
+                false,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of(new TransformationPreviewRequest.PreviewTransformationDto(null, null, null, 1, true)));
+
+        assertThatThrownBy(() -> service.parseSamples(request, file))
+                .isInstanceOf(TransformationEvaluationException.class)
+                .hasMessageContaining("upload limit");
+    }
+}

--- a/docs/wiki/API-Reference.md
+++ b/docs/wiki/API-Reference.md
@@ -340,12 +340,20 @@ curl -X POST "https://recon.example.com/api/admin/reconciliations/42/sources/CAS
 | Endpoint | Method | Description |
 | --- | --- | --- |
 | `/api/admin/transformations/validate` | POST | Validates canonical field transformation chains before publishing. |
-| `/api/admin/transformations/preview` | POST | Applies transformations to sample data and returns a preview payload. |
+| `/api/admin/transformations/preview` | POST | Applies transformations to sample data supplied inline and returns a preview payload. |
+| `/api/admin/transformations/preview/upload` | POST | Accepts a sample file (CSV, Excel, JSON, XML, delimited text) plus parsing options and streams back up to ten transformed rows. |
 | `/api/admin/transformations/groovy/test` | POST | Executes Groovy scripts against synthetic inputs to validate custom logic. |
 | `/api/admin/transformations/samples` | GET | Fetches source data samples for a definition/source combination. Query params: `definitionId`, `sourceCode`, `limit`. |
 
 Validation and preview endpoints accept payloads describing the canonical field, transformations, and sample input values. If a
 transformation fails, the API responds with `400 Bad Request` and a descriptive error message.
+
+The upload-based preview endpoint receives a multipart request with:
+
+- **request** — JSON body conforming to `TransformationFilePreviewUploadRequest` (file type, header
+  flag, delimiter/record path, value column, row limit, and the transformation chain to execute).
+- **file** — The sample data to parse. The API enforces a 2 MiB limit and returns at most ten
+  transformed rows alongside any row-level errors.
 
 ### 7.4 Error Handling & Conventions
 - **HTTP 400** — Validation failures (missing fields, malformed query parameters, transformation errors).

--- a/docs/wiki/Admin-Configurator-Guide.md
+++ b/docs/wiki/Admin-Configurator-Guide.md
@@ -225,7 +225,9 @@ value = amount
     tell the wizard whether headers are present (or set them implicitly with `COLUMN_1`, `COLUMN_2`,
     ...), tweak the delimiter or sheet name, and optionally provide a record path for hierarchical
     formats. The wizard previews the first ten rows, runs the entire transformation chain, and calls
-    out row-level errors so you can adjust scripts without ingesting data.
+    out row-level errors so you can adjust scripts without ingesting data. The maximum upload size
+    defaults to 2 MiB and can be tuned with the `admin.transformations.preview.max-upload-bytes`
+    configuration property.
   - **Load live samples:** Once a batch has completed, you can still fetch persisted rows and launch
     the Groovy tester to validate against production data. Both upload and live samples share the
     same diff view so you can compare raw and transformed values quickly.

--- a/docs/wiki/Admin-Configurator-Guide.md
+++ b/docs/wiki/Admin-Configurator-Guide.md
@@ -118,8 +118,11 @@ you can pause and resume.
   - LLM prompt templates that call OpenAI to normalise or enrich field values
 - Use **Validate** to compile transformations immediately. Errors display inline with actionable
   messages.
-- **Groovy tester:** After ingesting at least one batch, click *Load sample rows* to fetch live
-  records, edit the script, and hit *Run test* to see the evaluated result beside the raw payload.
+- **Preview & Test panel:** Upload a sample file (CSV, delimited text, Excel, JSON, or XML) and
+  specify whether headers are present, the delimiter, or a record path to simulate transformations
+  before any data is ingested. The preview runs the full transformation chain against the first ten
+  records and highlights errors per row. You can still load recent ingestion rows and run the
+  Groovy tester against live data when you want to compare behaviour with production batches.
 
 #### LLM prompt transformations
 
@@ -217,12 +220,19 @@ value = amount
 
 ### 6.2 Sample Data Preview
 
-- For Groovy scripts, use the *Preview & Test* panel:
-  1. Load sample rows from recent ingestion batches.
-  2. Inspect the raw JSON payload and current canonical value.
-  3. Execute the script and review the resulting value.
-- For formula/pipeline transformations, the **Preview** button (if the source provides test rows)
-  evaluates the value and surfaces the output with before/after comparisons.
+- The *Preview & Test* panel supports two complementary workflows:
+  - **Upload sample file:** Drop a CSV, delimited text, Excel workbook, JSON document, or XML payload,
+    tell the wizard whether headers are present (or set them implicitly with `COLUMN_1`, `COLUMN_2`,
+    ...), tweak the delimiter or sheet name, and optionally provide a record path for hierarchical
+    formats. The wizard previews the first ten rows, runs the entire transformation chain, and calls
+    out row-level errors so you can adjust scripts without ingesting data.
+  - **Load live samples:** Once a batch has completed, you can still fetch persisted rows and launch
+    the Groovy tester to validate against production data. Both upload and live samples share the
+    same diff view so you can compare raw and transformed values quickly.
+- Formula and pipeline transformations reuse the same panel, so a single preview covers mixed chains
+  (e.g. Groovy followed by pipeline cleanup).
+- To prevent accidental publishes, the wizard requires at least one successful preview per mapping
+  that contains active transformations before you can leave the Schema step.
 
 ### 6.3 Harness & Automation Support
 

--- a/frontend/src/app/components/admin/admin-reconciliation-wizard.component.css
+++ b/frontend/src/app/components/admin/admin-reconciliation-wizard.component.css
@@ -281,6 +281,10 @@
   color: #dc2626;
 }
 
+.warning {
+  color: #b45309;
+}
+
 .hint {
   font-size: 0.85rem;
   color: #64748b;
@@ -318,6 +322,65 @@
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
+}
+
+.upload-tools {
+  display: grid;
+  gap: 0.6rem;
+  padding: 0.75rem;
+  border: 1px dashed #cbd5f5;
+  border-radius: 6px;
+  background: #ffffff;
+}
+
+.upload-tools label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.upload-tools input,
+.upload-tools select,
+.upload-tools textarea {
+  padding: 0.4rem 0.5rem;
+  border-radius: 6px;
+  border: 1px solid #cbd5f5;
+}
+
+.upload-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.upload-results {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.upload-result {
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 0.6rem 0.75rem;
+  background: #f8fafc;
+}
+
+.upload-result header {
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+
+.upload-result details {
+  font-size: 0.85rem;
+}
+
+.upload-result pre {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 0.5rem;
+  border-radius: 4px;
+  overflow: auto;
 }
 
 .report-flags {

--- a/frontend/src/app/components/admin/admin-reconciliation-wizard.component.html
+++ b/frontend/src/app/components/admin/admin-reconciliation-wizard.component.html
@@ -119,6 +119,7 @@
     </section>
 
     <section *ngSwitchCase="'schema'" formArrayName="canonicalFields" class="schema-step">
+      <p class="error" *ngIf="schemaPreviewWarning">{{ schemaPreviewWarning }}</p>
       <article *ngFor="let fieldGroup of canonicalFields.controls; let i = index" [formGroupName]="i" class="field-card">
         <header>
           <h3>Field {{ i + 1 }}</h3>
@@ -154,8 +155,14 @@
           <h4>Mappings</h4>
           <div *ngFor="let mappingGroup of sourceMappings(i).controls; let m = index" [formGroupName]="m" class="mapping-row">
             <div class="mapping-grid">
-              <label>Source<input type="text" formControlName="sourceCode" /></label>
-              <label>Column<input type="text" formControlName="sourceColumn" /></label>
+              <label>Source<input type="text" formControlName="sourceCode" (input)="invalidateMappingPreview(i, m)" /></label>
+              <label
+                >Column<input
+                  type="text"
+                  formControlName="sourceColumn"
+                  (input)="onSourceColumnChange(i, m, $any($event.target).value)"
+                />
+              </label>
               <label>Legacy expression
                 <input type="text" formControlName="transformationExpression" placeholder="Optional legacy expression" />
               </label>
@@ -189,7 +196,14 @@
                 <div class="transformation-body">
                   <ng-container [ngSwitch]="transformationGroup.get('type')?.value">
                     <div *ngSwitchCase="'GROOVY_SCRIPT'" class="transformation-editor">
-                      <label>Groovy script<textarea formControlName="expression" rows="4" placeholder="return value"></textarea></label>
+                      <label
+                        >Groovy script<textarea
+                          formControlName="expression"
+                          rows="4"
+                          placeholder="return value"
+                          (input)="invalidateMappingPreview(i, m)"
+                        ></textarea
+                      ></label>
                       <div class="groovy-tools">
                         <div class="groovy-actions">
                           <button
@@ -241,7 +255,14 @@
                       </div>
                     </div>
                     <div *ngSwitchCase="'EXCEL_FORMULA'" class="transformation-editor">
-                      <label>Excel formula<input type="text" formControlName="expression" placeholder="=VALUE" /></label>
+                      <label
+                        >Excel formula<input
+                          type="text"
+                          formControlName="expression"
+                          placeholder="=VALUE"
+                          (input)="invalidateMappingPreview(i, m)"
+                        />
+                      </label>
                       <p class="hint">Use VALUE or column names (e.g. CASH_AMOUNT) as named references.</p>
                     </div>
                     <div *ngSwitchCase="'FUNCTION_PIPELINE'" class="transformation-editor" formArrayName="pipelineSteps">
@@ -252,7 +273,7 @@
                       >
                         <label>
                           Function
-                          <select formControlName="function">
+                          <select formControlName="function" (change)="invalidateMappingPreview(i, m)">
                             <option *ngFor="let fn of pipelineFunctionOptions" [value]="fn.value">{{ fn.label }}</option>
                           </select>
                         </label>
@@ -261,7 +282,13 @@
                             *ngFor="let argCtrl of pipelineStepArgs(i, m, t, s).controls; let a = index"
                             class="arg-row"
                           >
-                            <label>Arg {{ a + 1 }}<input [formControlName]="a" placeholder="Value or {{column}}" /></label>
+                            <label
+                              >Arg {{ a + 1 }}<input
+                                [formControlName]="a"
+                                placeholder="Value or {{column}}"
+                                (input)="invalidateMappingPreview(i, m)"
+                              />
+                            </label>
                             <button type="button" class="link" (click)="removePipelineArg(i, m, t, s, a)">Remove</button>
                           </div>
                           <button type="button" class="secondary" (click)="addPipelineArg(i, m, t, s)">Add argument</button>
@@ -278,16 +305,64 @@
                       <button type="button" class="secondary" (click)="addPipelineStep(i, m, t)">Add step</button>
                     </div>
                     <div *ngSwitchCase="'LLM_PROMPT'" class="transformation-editor" formGroupName="llmConfig">
-                      <label>Prompt template<textarea formControlName="promptTemplate" rows="4" placeholder="Normalize the value '{{value}}'"></textarea></label>
+                      <label
+                        >Prompt template<textarea
+                          formControlName="promptTemplate"
+                          rows="4"
+                          placeholder="Normalize the value '{{value}}'"
+                          (input)="invalidateMappingPreview(i, m)"
+                        ></textarea
+                      ></label>
                       <p class="hint">Use {{value}} for the incoming value and {{rawRecord}} for the JSON representation of the source row.</p>
-                      <label>JSON schema<textarea formControlName="jsonSchema" rows="4" placeholder="{ &quot;type&quot;: &quot;object&quot;, ... }"></textarea></label>
-                      <label>Result path<input type="text" formControlName="resultPath" placeholder="normalizedValue" /></label>
+                      <label
+                        >JSON schema<textarea
+                          formControlName="jsonSchema"
+                          rows="4"
+                          placeholder="{ &quot;type&quot;: &quot;object&quot;, ... }"
+                          (input)="invalidateMappingPreview(i, m)"
+                        ></textarea
+                      ></label>
+                      <label
+                        >Result path<input
+                          type="text"
+                          formControlName="resultPath"
+                          placeholder="normalizedValue"
+                          (input)="invalidateMappingPreview(i, m)"
+                        />
+                      </label>
                       <div class="grid">
-                        <label>Model<input type="text" formControlName="model" placeholder="Defaults to backend setting" /></label>
-                        <label>Temperature<input type="number" step="0.1" formControlName="temperature" /></label>
-                        <label>Max output tokens<input type="number" formControlName="maxOutputTokens" /></label>
+                        <label
+                          >Model<input
+                            type="text"
+                            formControlName="model"
+                            placeholder="Defaults to backend setting"
+                            (input)="invalidateMappingPreview(i, m)"
+                          />
+                        </label>
+                        <label
+                          >Temperature<input
+                            type="number"
+                            step="0.1"
+                            formControlName="temperature"
+                            (input)="invalidateMappingPreview(i, m)"
+                          />
+                        </label>
+                        <label
+                          >Max output tokens<input
+                            type="number"
+                            formControlName="maxOutputTokens"
+                            (input)="invalidateMappingPreview(i, m)"
+                          />
+                        </label>
                       </div>
-                      <label class="checkbox"><input type="checkbox" formControlName="includeRawRecord" /> Include raw record context</label>
+                      <label class="checkbox"
+                        ><input
+                          type="checkbox"
+                          formControlName="includeRawRecord"
+                          (change)="invalidateMappingPreview(i, m)"
+                        />
+                        Include raw record context</label
+                      >
                     </div>
                   </ng-container>
                 </div>
@@ -330,6 +405,129 @@
               <p class="error" *ngIf="previewState[previewKey(i, m)]?.error">
                 {{ previewState[previewKey(i, m)]?.error }}
               </p>
+              <p class="success" *ngIf="isMappingPreviewConfirmed(i, m) && !isMappingPreviewStale(i, m)">
+                Latest preview confirmed.
+              </p>
+              <p class="warning" *ngIf="isMappingPreviewStale(i, m)">
+                Preview is out of date. Re-run a sample preview to continue.
+              </p>
+              <div class="upload-tools">
+                <h6>Upload sample file</h6>
+                <label>
+                  File type
+                  <select
+                    [value]="sampleUploadStateFor(i, m).fileType"
+                    (change)="setSampleUploadOption(i, m, 'fileType', $any($event.target).value)"
+                  >
+                    <option value="CSV">CSV</option>
+                    <option value="DELIMITED">Delimited TXT</option>
+                    <option value="EXCEL">Excel</option>
+                    <option value="JSON">JSON</option>
+                    <option value="XML">XML</option>
+                  </select>
+                </label>
+                <label class="checkbox" *ngIf="['CSV', 'DELIMITED', 'EXCEL'].includes(sampleUploadStateFor(i, m).fileType)">
+                  <input
+                    type="checkbox"
+                    [checked]="sampleUploadStateFor(i, m).hasHeader"
+                    (change)="setSampleUploadOption(i, m, 'hasHeader', $any($event.target).checked)"
+                  />
+                  Has header row
+                </label>
+                <label *ngIf="['CSV', 'DELIMITED'].includes(sampleUploadStateFor(i, m).fileType)">
+                  Delimiter
+                  <input
+                    type="text"
+                    maxlength="1"
+                    [value]="sampleUploadStateFor(i, m).delimiter || ','"
+                    (input)="setSampleUploadOption(i, m, 'delimiter', $any($event.target).value)"
+                  />
+                </label>
+                <label *ngIf="sampleUploadStateFor(i, m).fileType === 'EXCEL'">
+                  Sheet name
+                  <input
+                    type="text"
+                    [value]="sampleUploadStateFor(i, m).sheetName || ''"
+                    (input)="setSampleUploadOption(i, m, 'sheetName', $any($event.target).value)"
+                  />
+                </label>
+                <label *ngIf="['JSON', 'XML'].includes(sampleUploadStateFor(i, m).fileType)">
+                  Record path
+                  <input
+                    type="text"
+                    placeholder="e.g. data.items"
+                    [value]="sampleUploadStateFor(i, m).recordPath || ''"
+                    (input)="setSampleUploadOption(i, m, 'recordPath', $any($event.target).value)"
+                  />
+                </label>
+                <label>
+                  Value column
+                  <input
+                    type="text"
+                    placeholder="COLUMN_1"
+                    [value]="sampleUploadStateFor(i, m).valueColumn || ''"
+                    (input)="setSampleUploadOption(i, m, 'valueColumn', $any($event.target).value)"
+                  />
+                </label>
+                <label>
+                  Encoding
+                  <input
+                    type="text"
+                    placeholder="UTF-8"
+                    [value]="sampleUploadStateFor(i, m).encoding || ''"
+                    (input)="setSampleUploadOption(i, m, 'encoding', $any($event.target).value)"
+                  />
+                </label>
+                <label>
+                  Max rows
+                  <input
+                    type="number"
+                    min="1"
+                    max="10"
+                    [value]="sampleUploadStateFor(i, m).limit"
+                    (input)="setSampleUploadOption(i, m, 'limit', $any($event.target).value)"
+                  />
+                </label>
+                <label>
+                  Sample file
+                  <input type="file" (change)="onSampleFileSelected(i, m, $event)" />
+                </label>
+                <p class="hint" *ngIf="sampleUploadStateFor(i, m).fileName">
+                  Selected: {{ sampleUploadStateFor(i, m).fileName }}
+                </p>
+                <div class="upload-actions">
+                  <button
+                    type="button"
+                    class="secondary"
+                    (click)="uploadSampleFile(i, m)"
+                    [disabled]="sampleUploadStateFor(i, m).uploading"
+                  >
+                    {{ sampleUploadStateFor(i, m).uploading ? 'Previewing…' : 'Upload & Preview' }}
+                  </button>
+                </div>
+                <p class="error" *ngIf="sampleUploadStateFor(i, m).error">
+                  {{ sampleUploadStateFor(i, m).error }}
+                </p>
+                <p class="hint" *ngIf="sampleUploadStateFor(i, m).rows.length === 10">
+                  Showing first 10 rows from the uploaded file.
+                </p>
+                <div class="upload-results" *ngIf="sampleUploadStateFor(i, m).rows.length">
+                  <div class="upload-result" *ngFor="let row of sampleUploadStateFor(i, m).rows">
+                    <header>Row {{ row.rowNumber }}</header>
+                    <p><strong>Input:</strong> {{ stringifyResult(row.valueBefore) }}</p>
+                    <p class="success" *ngIf="!row.error">
+                      <strong>Transformed:</strong> {{ stringifyResult(row.transformedValue) }}
+                    </p>
+                    <p class="error" *ngIf="row.error">
+                      <strong>Error:</strong> {{ row.error }}
+                    </p>
+                    <details>
+                      <summary>Raw record</summary>
+                      <pre>{{ row.rawRecord | json }}</pre>
+                    </details>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
           <button type="button" class="secondary" (click)="addMapping(i)">Add mapping</button>

--- a/frontend/src/app/components/admin/admin-reconciliation-wizard.component.ts
+++ b/frontend/src/app/components/admin/admin-reconciliation-wizard.component.ts
@@ -818,7 +818,7 @@ export class AdminReconciliationWizardComponent implements OnInit, OnDestroy {
       value = Number.isFinite(numeric) ? Math.min(Math.max(Math.trunc(numeric), 1), 10) : 10;
     }
     if (option === 'valueColumn' || option === 'delimiter' || option === 'sheetName' || option === 'recordPath' || option === 'encoding') {
-      value = this.normalize(typeof rawValue === 'string' ? rawValue : '') ?? undefined;
+      value = this.normalize(typeof rawValue === 'string' ? rawValue : '') || undefined;
     }
     const next: SampleUploadUiState = {
       ...state,
@@ -826,11 +826,16 @@ export class AdminReconciliationWizardComponent implements OnInit, OnDestroy {
     };
     if (option === 'fileType') {
       const fileType = value as TransformationSampleFileType;
+      const previousFileType = state.fileType;
       if (fileType === 'CSV') {
-        next.delimiter = next.delimiter || ',';
+        next.delimiter = state.delimiter && state.delimiter.length > 0 ? state.delimiter : ',';
         next.hasHeader = true;
       } else if (fileType === 'DELIMITED') {
-        next.delimiter = next.delimiter || '|';
+        const preservedDelimiter =
+          previousFileType === 'DELIMITED' && state.delimiter && state.delimiter.length > 0
+            ? state.delimiter
+            : undefined;
+        next.delimiter = preservedDelimiter;
         next.hasHeader = false;
       } else {
         next.delimiter = undefined;
@@ -908,7 +913,7 @@ export class AdminReconciliationWizardComponent implements OnInit, OnDestroy {
       hasHeader: state.hasHeader,
       delimiter:
         state.fileType === 'CSV' || state.fileType === 'DELIMITED'
-          ? (state.delimiter && state.delimiter.length > 0 ? state.delimiter : ',')
+          ? state.delimiter && state.delimiter.length > 0 ? state.delimiter : undefined
           : undefined,
       sheetName: state.fileType === 'EXCEL' ? (state.sheetName || undefined) : undefined,
       recordPath: state.fileType === 'JSON' || state.fileType === 'XML' ? state.recordPath || undefined : undefined,

--- a/frontend/src/app/components/admin/admin-reconciliation-wizard.component.ts
+++ b/frontend/src/app/components/admin/admin-reconciliation-wizard.component.ts
@@ -29,6 +29,10 @@ import {
   ReconciliationLifecycleStatus,
   TransformationPreviewRequest,
   TransformationPreviewResponse,
+  TransformationFilePreviewUploadRequest,
+  TransformationFilePreviewResponse,
+  TransformationFilePreviewRow,
+  TransformationSampleFileType,
   TransformationSampleRow,
   GroovyScriptTestRequest,
   TransformationType,
@@ -59,6 +63,24 @@ type LlmTransformationConfigFormValue = {
   temperature: number | null;
   maxOutputTokens: number | null;
   includeRawRecord: boolean;
+};
+
+type SampleUploadUiState = {
+  file?: File;
+  fileName?: string;
+  fileType: TransformationSampleFileType;
+  hasHeader: boolean;
+  delimiter?: string;
+  sheetName?: string;
+  recordPath?: string;
+  encoding?: string;
+  limit: number;
+  valueColumn?: string;
+  uploading: boolean;
+  rows: TransformationFilePreviewRow[];
+  error?: string;
+  confirmed: boolean;
+  stale: boolean;
 };
 
 @Component({
@@ -152,6 +174,11 @@ export class AdminReconciliationWizardComponent implements OnInit, OnDestroy {
   transformationSamples: Record<string, TransformationSampleRow[]> = {};
   selectedSampleIndex: Record<string, number> = {};
   groovyTestState: Record<string, { running: boolean; result?: string; error?: string }> = {};
+  sampleUploadState: Record<string, SampleUploadUiState> = {};
+  schemaPreviewWarning: string | null = null;
+
+  private previewConfirmations = new Set<string>();
+  private previewStaleKeys = new Set<string>();
 
   private readonly destroy$ = new Subject<void>();
   private patchedFromDetail = false;
@@ -309,9 +336,14 @@ export class AdminReconciliationWizardComponent implements OnInit, OnDestroy {
     const mappings = this.sourceMappings(fieldIndex);
     mappings.push(this.createMappingGroup(mapping));
     this.ensurePreviewState(fieldIndex, mappings.length - 1);
+    this.sampleUploadStateFor(fieldIndex, mappings.length - 1);
   }
 
   removeMapping(fieldIndex: number, mappingIndex: number): void {
+    const key = this.previewKey(fieldIndex, mappingIndex);
+    this.previewConfirmations.delete(key);
+    this.previewStaleKeys.delete(key);
+    delete this.sampleUploadState[key];
     this.sourceMappings(fieldIndex).removeAt(mappingIndex);
     this.rebuildPreviewState();
   }
@@ -322,18 +354,22 @@ export class AdminReconciliationWizardComponent implements OnInit, OnDestroy {
     transformation?: AdminCanonicalFieldTransformation
   ): void {
     this.mappingTransformations(fieldIndex, mappingIndex).push(this.createTransformationGroup(transformation));
+    this.invalidateMappingPreview(fieldIndex, mappingIndex);
   }
 
   removeTransformation(fieldIndex: number, mappingIndex: number, transformationIndex: number): void {
     this.mappingTransformations(fieldIndex, mappingIndex).removeAt(transformationIndex);
+    this.invalidateMappingPreview(fieldIndex, mappingIndex);
   }
 
   addPipelineStep(fieldIndex: number, mappingIndex: number, transformationIndex: number): void {
     this.pipelineSteps(fieldIndex, mappingIndex, transformationIndex).push(this.createPipelineStepGroup());
+    this.invalidateMappingPreview(fieldIndex, mappingIndex);
   }
 
   removePipelineStep(fieldIndex: number, mappingIndex: number, transformationIndex: number, stepIndex: number): void {
     this.pipelineSteps(fieldIndex, mappingIndex, transformationIndex).removeAt(stepIndex);
+    this.invalidateMappingPreview(fieldIndex, mappingIndex);
   }
 
   addPipelineArg(
@@ -345,6 +381,7 @@ export class AdminReconciliationWizardComponent implements OnInit, OnDestroy {
     this.pipelineStepArgs(fieldIndex, mappingIndex, transformationIndex, stepIndex).push(
       this.fb.control('')
     );
+    this.invalidateMappingPreview(fieldIndex, mappingIndex);
   }
 
   removePipelineArg(
@@ -355,6 +392,7 @@ export class AdminReconciliationWizardComponent implements OnInit, OnDestroy {
     argIndex: number
   ): void {
     this.pipelineStepArgs(fieldIndex, mappingIndex, transformationIndex, stepIndex).removeAt(argIndex);
+    this.invalidateMappingPreview(fieldIndex, mappingIndex);
   }
 
   addReportTemplate(report?: AdminReportTemplate): void {
@@ -409,6 +447,7 @@ export class AdminReconciliationWizardComponent implements OnInit, OnDestroy {
       }
     }
     group.get('validationMessage')?.setValue('');
+    this.invalidateMappingPreview(fieldIndex, mappingIndex);
   }
 
   addAccessEntry(entry?: AdminAccessControlEntry): void {
@@ -494,10 +533,13 @@ export class AdminReconciliationWizardComponent implements OnInit, OnDestroy {
             result: this.toDisplayResult(response),
             error: undefined
           };
+          this.markPreviewConfirmed(key);
         },
         error: (error) => {
           const details = error?.error?.details ?? error?.error ?? 'Preview failed.';
           this.previewState[key] = { ...state, error: details };
+          this.previewConfirmations.delete(key);
+          this.previewStaleKeys.add(key);
         }
       });
   }
@@ -623,6 +665,7 @@ export class AdminReconciliationWizardComponent implements OnInit, OnDestroy {
       ...this.previewState[key],
       [property]: newValue
     };
+    this.invalidateMappingPreview(fieldIndex, mappingIndex);
   }
 
   getGroovyTestState(fieldIndex: number, mappingIndex: number, transformationIndex: number): {
@@ -660,6 +703,8 @@ export class AdminReconciliationWizardComponent implements OnInit, OnDestroy {
 
   private rebuildPreviewState(): void {
     const next: Record<string, { value: string; raw: string; result?: string; error?: string }> = {};
+    const uploadNext: Record<string, SampleUploadUiState> = {};
+    const validKeys = new Set<string>();
     this.canonicalFields.controls.forEach((_, fieldIndex) => {
       this.sourceMappings(fieldIndex).controls.forEach((__, mappingIndex) => {
         const key = this.previewKey(fieldIndex, mappingIndex);
@@ -670,9 +715,26 @@ export class AdminReconciliationWizardComponent implements OnInit, OnDestroy {
           result: previous?.result,
           error: undefined
         };
+        const priorUpload = this.sampleUploadState[key];
+        const defaultState = this.createDefaultSampleUploadState(fieldIndex, mappingIndex);
+        const merged: SampleUploadUiState = {
+          ...defaultState,
+          ...priorUpload,
+          valueColumn: priorUpload?.valueColumn ?? defaultState.valueColumn,
+          rows: priorUpload?.rows ?? [],
+          uploading: false,
+          confirmed: this.previewConfirmations.has(key),
+          stale: this.previewStaleKeys.has(key),
+          error: priorUpload?.error
+        };
+        uploadNext[key] = merged;
+        validKeys.add(key);
       });
     });
     this.previewState = next;
+    this.sampleUploadState = uploadNext;
+    this.previewConfirmations = new Set([...this.previewConfirmations].filter((key) => validKeys.has(key)));
+    this.previewStaleKeys = new Set([...this.previewStaleKeys].filter((key) => validKeys.has(key)));
   }
 
   private applySampleToPreview(fieldIndex: number, mappingIndex: number, sampleIndex: number): void {
@@ -695,6 +757,15 @@ export class AdminReconciliationWizardComponent implements OnInit, OnDestroy {
       error: undefined
     };
     this.selectedSampleIndex[key] = sampleIndex;
+    const uploadState = this.sampleUploadStateFor(fieldIndex, mappingIndex);
+    this.sampleUploadState[key] = {
+      ...uploadState,
+      valueColumn: uploadState.valueColumn ?? (column || undefined),
+      confirmed: false,
+      stale: true
+    };
+    this.previewConfirmations.delete(key);
+    this.previewStaleKeys.add(key);
   }
 
   private setGroovyTestState(
@@ -721,7 +792,262 @@ export class AdminReconciliationWizardComponent implements OnInit, OnDestroy {
     return matchedKey ? rawRecord[matchedKey] : undefined;
   }
 
-  private stringifyResult(value: unknown): string {
+  sampleUploadStateFor(fieldIndex: number, mappingIndex: number): SampleUploadUiState {
+    const key = this.previewKey(fieldIndex, mappingIndex);
+    if (!this.sampleUploadState[key]) {
+      this.sampleUploadState[key] = this.createDefaultSampleUploadState(fieldIndex, mappingIndex);
+    }
+    return this.sampleUploadState[key];
+  }
+
+  onSourceColumnChange(fieldIndex: number, mappingIndex: number, value: string): void {
+    this.invalidateMappingPreview(fieldIndex, mappingIndex, { valueColumn: value });
+  }
+
+  setSampleUploadOption(
+    fieldIndex: number,
+    mappingIndex: number,
+    option: keyof SampleUploadUiState,
+    rawValue: unknown
+  ): void {
+    const key = this.previewKey(fieldIndex, mappingIndex);
+    const state = this.sampleUploadStateFor(fieldIndex, mappingIndex);
+    let value: unknown = rawValue;
+    if (option === 'limit') {
+      const numeric = Number(rawValue);
+      value = Number.isFinite(numeric) ? Math.min(Math.max(Math.trunc(numeric), 1), 10) : 10;
+    }
+    if (option === 'valueColumn' || option === 'delimiter' || option === 'sheetName' || option === 'recordPath' || option === 'encoding') {
+      value = this.normalize(typeof rawValue === 'string' ? rawValue : '') ?? undefined;
+    }
+    const next: SampleUploadUiState = {
+      ...state,
+      [option]: value as SampleUploadUiState[typeof option]
+    };
+    if (option === 'fileType') {
+      const fileType = value as TransformationSampleFileType;
+      if (fileType === 'CSV') {
+        next.delimiter = next.delimiter || ',';
+        next.hasHeader = true;
+      } else if (fileType === 'DELIMITED') {
+        next.delimiter = next.delimiter || '|';
+        next.hasHeader = false;
+      } else {
+        next.delimiter = undefined;
+      }
+      if (fileType !== 'EXCEL') {
+        next.sheetName = '';
+      }
+      if (!['JSON', 'XML'].includes(fileType)) {
+        next.recordPath = '';
+      }
+      if (fileType === 'JSON' || fileType === 'XML') {
+        next.hasHeader = false;
+      }
+    }
+    if (!['rows', 'uploading', 'error'].includes(option)) {
+      next.confirmed = false;
+      next.stale = true;
+      next.error = undefined;
+      this.previewConfirmations.delete(key);
+      this.previewStaleKeys.add(key);
+    }
+    this.sampleUploadState[key] = next;
+  }
+
+  onSampleFileSelected(fieldIndex: number, mappingIndex: number, event: Event): void {
+    const target = event.target as HTMLInputElement | null;
+    const file = target?.files && target.files.length > 0 ? target.files[0] : undefined;
+    const key = this.previewKey(fieldIndex, mappingIndex);
+    const state = this.sampleUploadStateFor(fieldIndex, mappingIndex);
+    if (!file) {
+      this.sampleUploadState[key] = {
+        ...state,
+        file: undefined,
+        fileName: undefined
+      };
+      return;
+    }
+    this.sampleUploadState[key] = {
+      ...state,
+      file,
+      fileName: file.name,
+      confirmed: false,
+      stale: true,
+      error: undefined
+    };
+    this.previewConfirmations.delete(key);
+    this.previewStaleKeys.add(key);
+  }
+
+  uploadSampleFile(fieldIndex: number, mappingIndex: number): void {
+    const key = this.previewKey(fieldIndex, mappingIndex);
+    const state = this.sampleUploadStateFor(fieldIndex, mappingIndex);
+    const file = state.file;
+    if (!file) {
+      this.sampleUploadState[key] = {
+        ...state,
+        error: 'Select a sample file to preview transformations.'
+      };
+      return;
+    }
+
+    const transformations = this.buildTransformationsPayload(fieldIndex, mappingIndex);
+    if (transformations.length === 0) {
+      this.sampleUploadState[key] = {
+        ...state,
+        error: 'Add at least one transformation before running a preview.'
+      };
+      return;
+    }
+
+    const mappingGroup = this.sourceMappings(fieldIndex).at(mappingIndex) as FormGroup;
+    const defaultColumn = this.normalize(mappingGroup.get('sourceColumn')?.value);
+    const payload: TransformationFilePreviewUploadRequest = {
+      fileType: state.fileType,
+      hasHeader: state.hasHeader,
+      delimiter:
+        state.fileType === 'CSV' || state.fileType === 'DELIMITED'
+          ? (state.delimiter && state.delimiter.length > 0 ? state.delimiter : ',')
+          : undefined,
+      sheetName: state.fileType === 'EXCEL' ? (state.sheetName || undefined) : undefined,
+      recordPath: state.fileType === 'JSON' || state.fileType === 'XML' ? state.recordPath || undefined : undefined,
+      valueColumn: this.normalize(state.valueColumn) ?? defaultColumn ?? undefined,
+      encoding: state.encoding || undefined,
+      limit: state.limit ?? 10,
+      transformations: transformations.map((transformation) => ({
+        type: transformation.type,
+        expression: transformation.expression ?? undefined,
+        configuration: transformation.configuration ?? undefined,
+        displayOrder: transformation.displayOrder ?? undefined,
+        active: transformation.active
+      }))
+    };
+
+    this.sampleUploadState[key] = {
+      ...state,
+      uploading: true,
+      error: undefined,
+      rows: []
+    };
+    this.previewConfirmations.delete(key);
+    this.previewStaleKeys.add(key);
+
+    this.state
+      .previewTransformationFromFile(payload, file)
+      .pipe(take(1))
+      .subscribe({
+        next: (response: TransformationFilePreviewResponse) => {
+          const rows = response.rows ?? [];
+          const success = rows.length > 0;
+          this.sampleUploadState[key] = {
+            ...this.sampleUploadState[key],
+            uploading: false,
+            rows,
+            error: success ? undefined : 'No rows were returned from the uploaded file.',
+            confirmed: success,
+            stale: !success
+          };
+          if (success) {
+            this.markPreviewConfirmed(key);
+          }
+        },
+        error: (error) => {
+          const details = error?.error?.details ?? error?.error ?? 'Preview failed.';
+          this.sampleUploadState[key] = {
+            ...this.sampleUploadState[key],
+            uploading: false,
+            error: typeof details === 'string' ? details : 'Preview failed.'
+          };
+        }
+      });
+  }
+
+  isMappingPreviewConfirmed(fieldIndex: number, mappingIndex: number): boolean {
+    return this.previewConfirmations.has(this.previewKey(fieldIndex, mappingIndex));
+  }
+
+  isMappingPreviewStale(fieldIndex: number, mappingIndex: number): boolean {
+    return this.previewStaleKeys.has(this.previewKey(fieldIndex, mappingIndex));
+  }
+
+  private markPreviewConfirmed(key: string): void {
+    this.previewConfirmations.add(key);
+    this.previewStaleKeys.delete(key);
+    const state = this.sampleUploadState[key];
+    if (state) {
+      this.sampleUploadState[key] = {
+        ...state,
+        confirmed: true,
+        stale: false,
+        error: undefined
+      };
+    }
+  }
+
+  invalidateMappingPreview(
+    fieldIndex: number,
+    mappingIndex: number,
+    options?: { valueColumn?: string }
+  ): void {
+    const key = this.previewKey(fieldIndex, mappingIndex);
+    const state = this.sampleUploadStateFor(fieldIndex, mappingIndex);
+    this.previewConfirmations.delete(key);
+    this.previewStaleKeys.add(key);
+    this.sampleUploadState[key] = {
+      ...state,
+      confirmed: false,
+      stale: true,
+      valueColumn:
+        options && Object.prototype.hasOwnProperty.call(options, 'valueColumn')
+          ? this.normalize(options.valueColumn ?? '') ?? undefined
+          : state.valueColumn
+    };
+  }
+
+  private createDefaultSampleUploadState(fieldIndex: number, mappingIndex: number): SampleUploadUiState {
+    const mappingGroup = this.sourceMappings(fieldIndex).at(mappingIndex) as FormGroup;
+    const valueColumn = this.normalize(mappingGroup.get('sourceColumn')?.value) ?? undefined;
+    return {
+      fileType: 'CSV',
+      hasHeader: true,
+      delimiter: ',',
+      sheetName: '',
+      recordPath: '',
+      encoding: '',
+      limit: 10,
+      valueColumn,
+      uploading: false,
+      rows: [],
+      error: undefined,
+      confirmed: false,
+      stale: false
+    };
+  }
+
+  private collectMappingsMissingPreview(): string[] {
+    const missing: string[] = [];
+    this.canonicalFields.controls.forEach((fieldGroup, fieldIndex) => {
+      const fieldName = this.normalize(fieldGroup.get('canonicalName')?.value) ?? `Field ${fieldIndex + 1}`;
+      const mappings = this.sourceMappings(fieldIndex);
+      mappings.controls.forEach((mappingGroup, mappingIndex) => {
+        const transformations = this.mappingTransformations(fieldIndex, mappingIndex);
+        const hasActive = transformations.controls.some((group) => !!group.get('active')?.value);
+        if (!hasActive) {
+          return;
+        }
+        const key = this.previewKey(fieldIndex, mappingIndex);
+        if (!this.previewConfirmations.has(key)) {
+          const sourceCode = this.normalize(mappingGroup.get('sourceCode')?.value) ?? 'source';
+          const column = this.normalize(mappingGroup.get('sourceColumn')?.value) ?? 'value';
+          missing.push(`${fieldName} (${sourceCode}/${column})`);
+        }
+      });
+    });
+    return missing;
+  }
+
+  stringifyResult(value: unknown): string {
     if (value === null || value === undefined) {
       return 'null';
     }
@@ -1430,7 +1756,17 @@ export class AdminReconciliationWizardComponent implements OnInit, OnDestroy {
       case 'sources':
         return this.markArrayAndCheckValid(this.sources);
       case 'schema':
-        return this.markArrayAndCheckValid(this.canonicalFields);
+        if (!this.markArrayAndCheckValid(this.canonicalFields)) {
+          this.schemaPreviewWarning = null;
+          return false;
+        }
+        const missing = this.collectMappingsMissingPreview();
+        if (missing.length > 0) {
+          this.schemaPreviewWarning = `Run a sample preview for each mapping before continuing. Pending: ${missing.join(', ')}`;
+          return false;
+        }
+        this.schemaPreviewWarning = null;
+        return true;
       case 'reports':
         return this.markArrayAndCheckValid(this.reportTemplates);
       case 'access':

--- a/frontend/src/app/models/admin-api-models.ts
+++ b/frontend/src/app/models/admin-api-models.ts
@@ -299,3 +299,29 @@ export interface TransformationPreviewRequest {
 export interface TransformationPreviewResponse {
   result: unknown;
 }
+
+export type TransformationSampleFileType = 'CSV' | 'EXCEL' | 'JSON' | 'XML' | 'DELIMITED';
+
+export interface TransformationFilePreviewUploadRequest {
+  fileType: TransformationSampleFileType;
+  hasHeader: boolean;
+  delimiter?: string | null;
+  sheetName?: string | null;
+  recordPath?: string | null;
+  valueColumn?: string | null;
+  encoding?: string | null;
+  limit?: number | null;
+  transformations: PreviewTransformationDto[];
+}
+
+export interface TransformationFilePreviewRow {
+  rowNumber: number;
+  rawRecord: Record<string, unknown>;
+  valueBefore: unknown;
+  transformedValue: unknown;
+  error?: string | null;
+}
+
+export interface TransformationFilePreviewResponse {
+  rows: TransformationFilePreviewRow[];
+}

--- a/frontend/src/app/services/admin-reconciliation-state.service.ts
+++ b/frontend/src/app/services/admin-reconciliation-state.service.ts
@@ -13,6 +13,8 @@ import {
   TransformationValidationResponse,
   TransformationPreviewRequest,
   TransformationPreviewResponse,
+  TransformationFilePreviewUploadRequest,
+  TransformationFilePreviewResponse,
   TransformationSampleResponse,
   GroovyScriptTestRequest,
   GroovyScriptTestResponse
@@ -276,6 +278,19 @@ export class AdminReconciliationStateService {
       catchError((error) => {
         console.error('Groovy script execution failed', error);
         this.notifications.push('Groovy test execution failed.', 'error');
+        return throwError(() => error);
+      })
+    );
+  }
+
+  previewTransformationFromFile(
+    payload: TransformationFilePreviewUploadRequest,
+    file: File
+  ): Observable<TransformationFilePreviewResponse> {
+    return this.api.previewTransformationFromFile(payload, file).pipe(
+      catchError((error) => {
+        console.error('Failed to preview transformations from file', error);
+        this.notifications.push('Unable to preview transformations from the uploaded file.', 'error');
         return throwError(() => error);
       })
     );

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -32,6 +32,8 @@ import {
   GroovyScriptTestResponse,
   TransformationPreviewRequest,
   TransformationPreviewResponse,
+  TransformationFilePreviewUploadRequest,
+  TransformationFilePreviewResponse,
   TransformationSampleResponse,
   TransformationValidationRequest,
   TransformationValidationResponse,
@@ -276,6 +278,19 @@ export class ApiService {
 
   testGroovyScript(payload: GroovyScriptTestRequest): Observable<GroovyScriptTestResponse> {
     return this.http.post<GroovyScriptTestResponse>(`${BASE_URL}/admin/transformations/groovy/test`, payload);
+  }
+
+  previewTransformationFromFile(
+    payload: TransformationFilePreviewUploadRequest,
+    file: File
+  ): Observable<TransformationFilePreviewResponse> {
+    const formData = new FormData();
+    formData.append('request', new Blob([JSON.stringify(payload)], { type: 'application/json' }));
+    formData.append('file', file);
+    return this.http.post<TransformationFilePreviewResponse>(
+      `${BASE_URL}/admin/transformations/preview/upload`,
+      formData
+    );
   }
 
   private buildQueryParams(

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       start_period: 10s
 
   ldap:
-    image: bitnami/openldap:2.6
+    image: bitnamilegacy/openldap:2.6
     container_name: urp_ldap
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Summary
- add backend endpoint and parser to preview transformations from uploaded sample files
- extend admin wizard with upload UI, gating, and updated models/services
- refresh tests, docs, and automation coverage for the new preview workflow

## Testing
- ./backend/mvnw test
- cd frontend && npm test -- --watch=false --browsers=ChromeHeadless
- cd automation/regression && npm test
- examples/integration-harness/scripts/run_multi_example_e2e.sh
- ./scripts/local-dev.sh bootstrap
- ./scripts/local-dev.sh seed
- ./scripts/seed-historical.sh --days 3 --runs-per-day 1 --report-format NONE
- ./scripts/verify-historical-seed.sh --days 3 --runs-per-day 1 --skip-export-check