### PR TITLE
feat: add AI-assisted Groovy authoring

### DIFF
--- a/backend/src/main/java/com/universal/reconciliation/controller/admin/AdminTransformationController.java
+++ b/backend/src/main/java/com/universal/reconciliation/controller/admin/AdminTransformationController.java
@@ -1,5 +1,7 @@
 package com.universal.reconciliation.controller.admin;
 
+import com.universal.reconciliation.domain.dto.admin.GroovyScriptGenerationRequest;
+import com.universal.reconciliation.domain.dto.admin.GroovyScriptGenerationResponse;
 import com.universal.reconciliation.domain.dto.admin.GroovyScriptTestRequest;
 import com.universal.reconciliation.domain.dto.admin.GroovyScriptTestResponse;
 import com.universal.reconciliation.domain.dto.admin.TransformationFilePreviewResponse;
@@ -53,6 +55,12 @@ public class AdminTransformationController {
             @Valid @RequestPart("request") TransformationFilePreviewUploadRequest request,
             @RequestPart("file") MultipartFile file) {
         return transformationService.previewFromSampleFile(request, file);
+    }
+
+    @PostMapping("/groovy/generate")
+    public GroovyScriptGenerationResponse generateGroovy(
+            @Valid @RequestBody GroovyScriptGenerationRequest request) {
+        return transformationService.generateGroovyScript(request);
     }
 
     @PostMapping("/groovy/test")

--- a/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/GroovyScriptGenerationRequest.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/GroovyScriptGenerationRequest.java
@@ -1,0 +1,14 @@
+package com.universal.reconciliation.domain.dto.admin;
+
+import com.universal.reconciliation.domain.enums.FieldDataType;
+import jakarta.validation.constraints.NotBlank;
+import java.util.Map;
+
+public record GroovyScriptGenerationRequest(
+        @NotBlank String prompt,
+        @NotBlank String fieldName,
+        FieldDataType fieldDataType,
+        String sourceCode,
+        String sourceColumn,
+        Object sampleValue,
+        Map<String, Object> rawRecord) {}

--- a/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/GroovyScriptGenerationResponse.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/GroovyScriptGenerationResponse.java
@@ -1,0 +1,3 @@
+package com.universal.reconciliation.domain.dto.admin;
+
+public record GroovyScriptGenerationResponse(String script, String summary) {}

--- a/backend/src/main/java/com/universal/reconciliation/service/admin/AdminTransformationService.java
+++ b/backend/src/main/java/com/universal/reconciliation/service/admin/AdminTransformationService.java
@@ -2,6 +2,8 @@ package com.universal.reconciliation.service.admin;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.universal.reconciliation.domain.dto.admin.GroovyScriptGenerationRequest;
+import com.universal.reconciliation.domain.dto.admin.GroovyScriptGenerationResponse;
 import com.universal.reconciliation.domain.dto.admin.GroovyScriptTestRequest;
 import com.universal.reconciliation.domain.dto.admin.GroovyScriptTestResponse;
 import com.universal.reconciliation.domain.dto.admin.TransformationFilePreviewResponse;
@@ -52,6 +54,7 @@ public class AdminTransformationService {
     private final SourceDataRecordRepository recordRepository;
     private final ObjectMapper objectMapper;
     private final TransformationSampleFileService sampleFileService;
+    private final GroovyScriptAuthoringService groovyScriptAuthoringService;
 
     public AdminTransformationService(
             DataTransformationService transformationService,
@@ -60,7 +63,8 @@ public class AdminTransformationService {
             SourceDataBatchRepository batchRepository,
             SourceDataRecordRepository recordRepository,
             ObjectMapper objectMapper,
-            TransformationSampleFileService sampleFileService) {
+            TransformationSampleFileService sampleFileService,
+            GroovyScriptAuthoringService groovyScriptAuthoringService) {
         this.transformationService = transformationService;
         this.definitionRepository = definitionRepository;
         this.sourceRepository = sourceRepository;
@@ -68,6 +72,7 @@ public class AdminTransformationService {
         this.recordRepository = recordRepository;
         this.objectMapper = objectMapper;
         this.sampleFileService = sampleFileService;
+        this.groovyScriptAuthoringService = groovyScriptAuthoringService;
     }
 
     public TransformationValidationResponse validate(@Valid TransformationValidationRequest request) {
@@ -92,6 +97,12 @@ public class AdminTransformationService {
         } catch (TransformationEvaluationException ex) {
             throw ex;
         }
+    }
+
+    public GroovyScriptGenerationResponse generateGroovyScript(@Valid GroovyScriptGenerationRequest request) {
+        GroovyScriptGenerationResponse response = groovyScriptAuthoringService.generate(request);
+        transformationService.validateGroovyScript(response.script());
+        return response;
     }
 
     public GroovyScriptTestResponse testGroovyScript(@Valid GroovyScriptTestRequest request) {

--- a/backend/src/main/java/com/universal/reconciliation/service/admin/GroovyScriptAuthoringService.java
+++ b/backend/src/main/java/com/universal/reconciliation/service/admin/GroovyScriptAuthoringService.java
@@ -1,0 +1,175 @@
+package com.universal.reconciliation.service.admin;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.universal.reconciliation.config.OpenAiProperties;
+import com.universal.reconciliation.domain.dto.admin.GroovyScriptGenerationRequest;
+import com.universal.reconciliation.domain.dto.admin.GroovyScriptGenerationResponse;
+import com.universal.reconciliation.service.ai.OpenAiClient;
+import com.universal.reconciliation.service.ai.OpenAiClientException;
+import com.universal.reconciliation.service.ai.OpenAiPromptRequest;
+import com.universal.reconciliation.service.transform.TransformationEvaluationException;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+public class GroovyScriptAuthoringService {
+
+    private static final Map<String, Object> RESPONSE_SCHEMA = Map.of(
+            "type",
+            "object",
+            "properties",
+            Map.of(
+                    "script",
+                    Map.of(
+                            "type",
+                            "string",
+                            "description",
+                            "Groovy snippet that can be saved directly without further editing."),
+                    "summary",
+                    Map.of(
+                            "type",
+                            "string",
+                            "description",
+                            "Short explanation of how the script fulfils the requirement.")),
+            "required",
+            List.of("script"),
+            "additionalProperties",
+            false);
+
+    private static final double DEFAULT_TEMPERATURE = 0.15d;
+    private static final int DEFAULT_MAX_TOKENS = 600;
+
+    private final OpenAiClient openAiClient;
+    private final ObjectMapper objectMapper;
+    private final OpenAiProperties properties;
+
+    public GroovyScriptAuthoringService(
+            OpenAiClient openAiClient, ObjectMapper objectMapper, OpenAiProperties properties) {
+        this.openAiClient = openAiClient;
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+    }
+
+    public GroovyScriptGenerationResponse generate(GroovyScriptGenerationRequest request) {
+        String prompt = buildPrompt(request);
+        try {
+            String response = openAiClient.completeJson(new OpenAiPromptRequest(
+                    null, prompt, RESPONSE_SCHEMA, DEFAULT_TEMPERATURE, DEFAULT_MAX_TOKENS));
+            return parseResponse(response);
+        } catch (OpenAiClientException ex) {
+            throw new TransformationEvaluationException(ex.getMessage(), ex);
+        }
+    }
+
+    private GroovyScriptGenerationResponse parseResponse(String rawJson) {
+        try {
+            JsonNode root = objectMapper.readTree(rawJson);
+            JsonNode scriptNode = root.get("script");
+            if (scriptNode == null || scriptNode.isNull()) {
+                throw new TransformationEvaluationException("LLM response did not include a Groovy script.");
+            }
+            String script = sanitizeScript(scriptNode.asText());
+            if (!StringUtils.hasText(script)) {
+                throw new TransformationEvaluationException("Generated Groovy script was empty.");
+            }
+            JsonNode summaryNode = root.get("summary");
+            String summary = summaryNode != null && !summaryNode.isNull() ? summaryNode.asText().trim() : null;
+            if (!StringUtils.hasText(summary)) {
+                summary = null;
+            }
+            return new GroovyScriptGenerationResponse(script, summary);
+        } catch (JsonProcessingException ex) {
+            throw new TransformationEvaluationException("Failed to parse LLM response as JSON", ex);
+        }
+    }
+
+    private String sanitizeScript(String script) {
+        if (script == null) {
+            return null;
+        }
+        String trimmed = script.trim();
+        if (!trimmed.startsWith("```")) {
+            return trimmed;
+        }
+        int firstLineBreak = trimmed.indexOf('\n');
+        if (firstLineBreak >= 0) {
+            trimmed = trimmed.substring(firstLineBreak + 1);
+        }
+        int closingFence = trimmed.lastIndexOf("```");
+        if (closingFence >= 0) {
+            trimmed = trimmed.substring(0, closingFence);
+        }
+        return trimmed.trim();
+    }
+
+    private String buildPrompt(GroovyScriptGenerationRequest request) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("You are an assistant that writes Groovy snippets for the Universal Reconciliation Platform.\n");
+        builder.append("Scripts run inside a sandbox with these bindings: value (current field value) and row/raw (Map of source data).\n");
+        builder.append("The script must either return the transformed value or mutate the value binding.\n");
+        builder.append("Restrictions: no imports, no class definitions, no printing/logging, and only use methods available on String, Number, Object, and Map.\n");
+        builder.append("Always handle nulls defensively and prefer returning the new value.\n\n");
+
+        builder.append("Field context:\n");
+        builder.append("- Canonical field: ").append(request.fieldName()).append('\n');
+        if (request.fieldDataType() != null) {
+            builder.append("- Field data type: ").append(request.fieldDataType().name()).append('\n');
+        }
+        if (StringUtils.hasText(request.sourceCode())) {
+            builder.append("- Source code: ").append(request.sourceCode()).append('\n');
+        }
+        if (StringUtils.hasText(request.sourceColumn())) {
+            builder.append("- Source column: ").append(request.sourceColumn()).append('\n');
+        }
+        if (request.sampleValue() != null) {
+            builder.append("- Example current value: ")
+                    .append(renderSampleValue(request.sampleValue()))
+                    .append('\n');
+        }
+        if (request.rawRecord() != null && !request.rawRecord().isEmpty()) {
+            builder.append("- Example raw source row (JSON):\n");
+            builder.append(renderRawRecord(request.rawRecord())).append('\n');
+        }
+
+        builder.append("\nAdministrator request:\n");
+        builder.append(request.prompt().trim()).append('\n');
+
+        builder.append("\nRespond with JSON containing the Groovy script and a concise summary.\n");
+        builder.append("Ensure the script can be saved directly without additional editing.\n");
+
+        return builder.toString();
+    }
+
+    private String renderSampleValue(Object sampleValue) {
+        if (sampleValue == null) {
+            return "null";
+        }
+        try {
+            String json = objectMapper.writeValueAsString(sampleValue);
+            return truncate(json, 120);
+        } catch (JsonProcessingException ex) {
+            return truncate(String.valueOf(sampleValue), 120);
+        }
+    }
+
+    private String renderRawRecord(Map<String, Object> rawRecord) {
+        try {
+            String json = objectMapper.writeValueAsString(rawRecord);
+            int limit = Math.max(512, Math.min(properties.getDocumentCharacterLimit(), 4000));
+            return truncate(json, limit);
+        } catch (JsonProcessingException ex) {
+            return "{}";
+        }
+    }
+
+    private String truncate(String value, int maxCharacters) {
+        if (value == null || value.length() <= maxCharacters) {
+            return value;
+        }
+        return value.substring(0, maxCharacters) + "…";
+    }
+}

--- a/backend/src/test/java/com/universal/reconciliation/service/admin/GroovyScriptAuthoringServiceTest.java
+++ b/backend/src/test/java/com/universal/reconciliation/service/admin/GroovyScriptAuthoringServiceTest.java
@@ -1,0 +1,133 @@
+package com.universal.reconciliation.service.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.universal.reconciliation.config.OpenAiProperties;
+import com.universal.reconciliation.domain.dto.admin.GroovyScriptGenerationRequest;
+import com.universal.reconciliation.domain.dto.admin.GroovyScriptGenerationResponse;
+import com.universal.reconciliation.domain.enums.FieldDataType;
+import com.universal.reconciliation.service.ai.OpenAiClient;
+import com.universal.reconciliation.service.ai.OpenAiClientException;
+import com.universal.reconciliation.service.ai.OpenAiPromptRequest;
+import com.universal.reconciliation.service.transform.TransformationEvaluationException;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GroovyScriptAuthoringServiceTest {
+
+    @Mock
+    private OpenAiClient openAiClient;
+
+    private ObjectMapper objectMapper;
+    private OpenAiProperties properties;
+    private GroovyScriptAuthoringService service;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        properties = new OpenAiProperties();
+        properties.setDocumentCharacterLimit(800);
+        service = new GroovyScriptAuthoringService(openAiClient, objectMapper, properties);
+    }
+
+    @Test
+    void generateBuildsPromptWithContextAndParsesResponse() {
+        GroovyScriptGenerationRequest request = new GroovyScriptGenerationRequest(
+                "Normalize the trade amount to two decimals",
+                "Net Amount",
+                FieldDataType.DECIMAL,
+                "CUSTODY",
+                "net_amount",
+                123.4567,
+                Map.of("net_amount", "123.4567", "currency", "USD"));
+
+        when(openAiClient.completeJson(any()))
+                .thenReturn("{\"script\":\"return value\",\"summary\":\"Rounds to two decimals\"}");
+
+        GroovyScriptGenerationResponse response = service.generate(request);
+
+        assertThat(response.script()).isEqualTo("return value");
+        assertThat(response.summary()).isEqualTo("Rounds to two decimals");
+
+        ArgumentCaptor<OpenAiPromptRequest> promptCaptor = ArgumentCaptor.forClass(OpenAiPromptRequest.class);
+        verify(openAiClient).completeJson(promptCaptor.capture());
+        OpenAiPromptRequest promptRequest = promptCaptor.getValue();
+        assertThat(promptRequest.temperature()).isEqualTo(0.15d);
+        assertThat(promptRequest.maxOutputTokens()).isEqualTo(600);
+        String prompt = promptRequest.prompt();
+        assertThat(prompt)
+                .contains("Net Amount")
+                .contains("Field data type: DECIMAL")
+                .contains("Source column: net_amount")
+                .contains("Administrator request:")
+                .contains("123.4567")
+                .contains("currency");
+    }
+
+    @Test
+    void generateStripsCodeFenceFromResponse() {
+        GroovyScriptGenerationRequest request = new GroovyScriptGenerationRequest(
+                "Trim whitespace",
+                "Trade Reference",
+                FieldDataType.STRING,
+                null,
+                null,
+                "  TR-123  ",
+                Map.of());
+
+        when(openAiClient.completeJson(any()))
+                .thenReturn("{\"script\":\"```groovy\\nreturn value?.toString()?.trim()\\n```\"}");
+
+        GroovyScriptGenerationResponse response = service.generate(request);
+
+        assertThat(response.script()).isEqualTo("return value?.toString()?.trim()");
+        assertThat(response.summary()).isNull();
+    }
+
+    @Test
+    void generateThrowsWhenScriptMissing() {
+        GroovyScriptGenerationRequest request = new GroovyScriptGenerationRequest(
+                "Do something",
+                "Field",
+                null,
+                null,
+                null,
+                null,
+                Map.of());
+
+        when(openAiClient.completeJson(any())).thenReturn("{\"summary\":\"Nothing\"}");
+
+        assertThatThrownBy(() -> service.generate(request))
+                .isInstanceOf(TransformationEvaluationException.class)
+                .hasMessageContaining("did not include a Groovy script");
+    }
+
+    @Test
+    void generateWrapsOpenAiErrors() {
+        GroovyScriptGenerationRequest request = new GroovyScriptGenerationRequest(
+                "Something",
+                "Field",
+                null,
+                null,
+                null,
+                null,
+                Map.of());
+
+        when(openAiClient.completeJson(any())).thenThrow(new OpenAiClientException("API key missing"));
+
+        assertThatThrownBy(() -> service.generate(request))
+                .isInstanceOf(TransformationEvaluationException.class)
+                .hasMessageContaining("API key missing");
+    }
+}

--- a/docs/wiki/API-Reference.md
+++ b/docs/wiki/API-Reference.md
@@ -343,7 +343,10 @@ curl -X POST "https://recon.example.com/api/admin/reconciliations/42/sources/CAS
 | `/api/admin/transformations/preview` | POST | Applies transformations to sample data supplied inline and returns a preview payload. |
 | `/api/admin/transformations/preview/upload` | POST | Accepts a sample file (CSV, Excel, JSON, XML, delimited text) plus parsing options and streams back up to ten transformed rows. |
 | `/api/admin/transformations/groovy/test` | POST | Executes Groovy scripts against synthetic inputs to validate custom logic. |
+| `/api/admin/transformations/groovy/generate` | POST | Produces a Groovy script from an AI prompt along with a human-readable summary. |
 | `/api/admin/transformations/samples` | GET | Fetches source data samples for a definition/source combination. Query params: `definitionId`, `sourceCode`, `limit`. |
+
+The Groovy generation endpoint accepts a payload containing the administrator prompt plus optional context such as field metadata, the current preview value, and a raw source row. The response returns the compiled script string and a helper summary; the server validates the script before returning it.
 
 Validation and preview endpoints accept payloads describing the canonical field, transformations, and sample input values. If a
 transformation fails, the API responds with `400 Bad Request` and a descriptive error message.

--- a/docs/wiki/Admin-Configurator-Guide.md
+++ b/docs/wiki/Admin-Configurator-Guide.md
@@ -183,6 +183,14 @@ value = amount
   - Use `BigDecimal` for currency math to prevent floating-point drift.
   - Log complex cases via comments and document in the reconciliation notes.
 
+#### AI-assisted Groovy authoring
+
+- Open the **Describe transformation** assistant inside the Groovy editor to capture the business requirement in plain language.
+- Load a sample row before requesting a script so the LLM receives the current value (`value`) and raw source payload (`row`/`raw`) context automatically.
+- The platform injects Groovy sandbox rules (no imports, bindings only) and posts the request to the configured OpenAI endpoint.
+- The returned script is written directly into the editor and a short summary is displayed beneath the assistant. Always run **Validate** and **Run Groovy test** afterwards to confirm the behaviour.
+- If OpenAI credentials are missing or the call fails, the assistant surfaces the error and preserves the prompt so you can retry after adjusting settings.
+
 ### 5.2 Excel-style Formulas
 
 - Syntax mirrors Excel/Google Sheets functions. Named ranges are generated automatically:

--- a/frontend/src/app/components/admin/admin-reconciliation-wizard.component.css
+++ b/frontend/src/app/components/admin/admin-reconciliation-wizard.component.css
@@ -423,3 +423,31 @@
   margin-top: 1rem;
   color: #475569;
 }
+
+.groovy-assistant {
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  border: 1px dashed #cbd5f5;
+  border-radius: 6px;
+  background: #f1f5f9;
+}
+
+.groovy-assistant label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.groovy-assistant textarea {
+  resize: vertical;
+  min-height: 3rem;
+}
+
+.groovy-assistant-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}

--- a/frontend/src/app/components/admin/admin-reconciliation-wizard.component.html
+++ b/frontend/src/app/components/admin/admin-reconciliation-wizard.component.html
@@ -205,6 +205,33 @@
                         ></textarea
                       ></label>
                       <div class="groovy-tools">
+                        <ng-container *ngIf="getGroovyAssistantState(i, m, t) as assistantState">
+                          <div class="groovy-assistant">
+                            <label>
+                              Describe transformation<textarea
+                                rows="3"
+                                [value]="assistantState.prompt"
+                                placeholder="Explain how the source value should be transformed"
+                                (input)="onGroovyPromptChange(i, m, t, $event)"
+                              ></textarea>
+                            </label>
+                            <div class="groovy-assistant-actions">
+                              <button
+                                type="button"
+                                class="secondary"
+                                (click)="generateGroovyScript(i, m, t)"
+                                [disabled]="assistantState.generating"
+                              >
+                                {{ assistantState.generating ? 'Generating…' : 'Generate with AI' }}
+                              </button>
+                              <span class="hint" *ngIf="assistantState.generating">Requesting Groovy script…</span>
+                            </div>
+                            <p class="hint" *ngIf="assistantState.summary && !assistantState.generating">
+                              {{ assistantState.summary }}
+                            </p>
+                            <p class="error" *ngIf="assistantState.error">{{ assistantState.error }}</p>
+                          </div>
+                        </ng-container>
                         <div class="groovy-actions">
                           <button
                             type="button"

--- a/frontend/src/app/models/admin-api-models.ts
+++ b/frontend/src/app/models/admin-api-models.ts
@@ -106,6 +106,21 @@ export interface TransformationSampleResponse {
   rows: TransformationSampleRow[];
 }
 
+export interface GroovyScriptGenerationRequest {
+  prompt: string;
+  fieldName: string;
+  fieldDataType?: FieldDataType | null;
+  sourceCode?: string | null;
+  sourceColumn?: string | null;
+  sampleValue?: unknown;
+  rawRecord?: Record<string, unknown>;
+}
+
+export interface GroovyScriptGenerationResponse {
+  script: string;
+  summary?: string | null;
+}
+
 export interface GroovyScriptTestRequest {
   script: string;
   value?: unknown;

--- a/frontend/src/app/services/admin-reconciliation-state.service.ts
+++ b/frontend/src/app/services/admin-reconciliation-state.service.ts
@@ -16,6 +16,8 @@ import {
   TransformationFilePreviewUploadRequest,
   TransformationFilePreviewResponse,
   TransformationSampleResponse,
+  GroovyScriptGenerationRequest,
+  GroovyScriptGenerationResponse,
   GroovyScriptTestRequest,
   GroovyScriptTestResponse
 } from '../models/admin-api-models';
@@ -268,6 +270,19 @@ export class AdminReconciliationStateService {
       catchError((error) => {
         console.error('Failed to load transformation samples', error);
         this.notifications.push('Unable to load sample source rows.', 'error');
+        return throwError(() => error);
+      })
+    );
+  }
+
+  generateGroovyScript(
+    payload: GroovyScriptGenerationRequest
+  ): Observable<GroovyScriptGenerationResponse> {
+    return this.api.generateGroovyScript(payload).pipe(
+      catchError((error) => {
+        console.error('Groovy script generation failed', error);
+        const message = error?.error ?? 'Unable to generate Groovy script.';
+        this.notifications.push(message, 'error');
         return throwError(() => error);
       })
     );

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -28,6 +28,8 @@ import {
   AdminReconciliationRequest,
   AdminReconciliationSchema,
   AdminReconciliationSummaryPage,
+  GroovyScriptGenerationRequest,
+  GroovyScriptGenerationResponse,
   GroovyScriptTestRequest,
   GroovyScriptTestResponse,
   TransformationPreviewRequest,
@@ -274,6 +276,15 @@ export class ApiService {
       .set('sourceCode', sourceCode)
       .set('limit', String(limit));
     return this.http.get<TransformationSampleResponse>(`${BASE_URL}/admin/transformations/samples`, { params });
+  }
+
+  generateGroovyScript(
+    payload: GroovyScriptGenerationRequest
+  ): Observable<GroovyScriptGenerationResponse> {
+    return this.http.post<GroovyScriptGenerationResponse>(
+      `${BASE_URL}/admin/transformations/groovy/generate`,
+      payload
+    );
   }
 
   testGroovyScript(payload: GroovyScriptTestRequest): Observable<GroovyScriptTestResponse> {


### PR DESCRIPTION
## Summary
- introduce `GroovyScriptAuthoringService` to build OpenAI prompts, sanitise responses, and expose `/api/admin/transformations/groovy/generate`
- surface an AI assistant in the admin Groovy editor that captures prompts, injects preview context, and hydrates the generated script plus summary
- document the new workflow and extend automation coverage to mock the assistant during wizard authoring

## Testing
- ./mvnw test
- npm test -- --watch=false --browsers=ChromeHeadless
- npm install && npm test (automation/regression)
- APP_PORT=9090 examples/integration-harness/scripts/run_multi_example_e2e.sh
- ./scripts/local-dev.sh bootstrap
- ./scripts/local-dev.sh seed
- ./scripts/seed-historical.sh
- ./scripts/verify-historical-seed.sh --days 3 --runs-per-day 1 --skip-export-check
