### PR TITLE
Add comprehensive wiki reference for architecture and operations

### DIFF
--- a/docs/wiki/ARCHITECTURE.md
+++ b/docs/wiki/ARCHITECTURE.md
@@ -1,0 +1,172 @@
+# Platform Architecture
+
+The Universal Reconciliation Platform unifies configurable matching services, workflow automation, and an analyst-friendly UI. This document describes how each layer interacts, the guiding architectural principles, and the runtime/topology views required for implementation or review.
+
+## 1. Architectural Principles
+- **Configuration over code:** Reconciliation behavior is captured as metadata stored in MariaDB. Services load definitions at runtime to avoid code deployments for new use cases.
+- **Separation of duties:** Maker/checker flows are enforced end-to-end through access control entries, workflow services, and UI guardrails.
+- **Hexagonal boundaries:** Controllers convert HTTP requests into service calls; services focus on domain logic; repositories isolate persistence concerns.
+- **Observability by design:** Structured system events, run analytics, and export telemetry are emitted for every critical action to support compliance and debugging.
+- **Testable slices:** Each layer (backend, frontend, automation, ingestion) exposes fixtures and harnesses to support repeatable testing in CI and local environments.
+
+## 2. Logical Architecture
+
+```mermaid
+graph LR
+  subgraph Client
+    UI[Angular SPA]
+  end
+  subgraph Services
+    API[Spring Boot REST APIs]
+    Match[Matching Engine]
+    Workflow[Workflow Services]
+    Export[Excel/Reporting Engine]
+    Activity[System Activity Stream]
+  end
+  subgraph Data & Identity
+    DB[(MariaDB/H2)]
+    LDAP[(LDAP Directory)]
+  end
+  subgraph Integrations
+    ETL[Ingestion SDK & ETL Pipelines]
+    Schedulers[Schedulers/RPA]
+    Kafka[(Event Hooks)]
+    Observability[(APM/SIEM)]
+  end
+
+  UI -->|JWT| API
+  API --> Match
+  API --> Workflow
+  API --> Export
+  API --> Activity
+  API --> LDAP
+  Match --> DB
+  Workflow --> DB
+  Export --> DB
+  Activity --> Observability
+  ETL --> DB
+  Schedulers -->|Trigger Run| API
+  Kafka -->|Async Events| API
+```
+
+## 3. Backend Architecture (Spring Boot)
+
+### 3.1 Application Layer
+- **Entry Point:** [`UniversalReconciliationPlatformApplication`](../../backend/src/main/java/com/universal/reconciliation/UniversalReconciliationPlatformApplication.java) bootstraps Spring, enables async execution, and loads configuration profiles.
+- **Controllers:** REST endpoints are grouped under `controller/`, including reconciliation operations, break management, exports, system activity, authentication, admin metadata, and harness debugging.
+- **Exception Handling:** `RestExceptionHandler` translates domain/business exceptions into consistent HTTP responses for the UI.
+
+### 3.2 Domain & Services
+- **Domain Entities:** Located under `domain/entity`, representing reconciliations, runs, breaks, approvals, export jobs, transformations, access control entries, and audit events. Entities map to schema documented in [`Database-Schema.md`](Database-Schema.md).
+- **DTOs:** `domain/dto` provides serialization-friendly objects that mirror UI contracts, decoupling persistence from payloads.
+- **Reconciliation Service:** Coordinates definition access, run execution, break persistence, analytics calculation, and audit events. Depends on repositories and the matching engine.
+- **Matching Engine:** `service/matching` provides metadata-driven comparison logic. `MatchingEngine.execute` generates `MatchingResult`, which includes matched counts and break candidates for persistence.
+- **Break Lifecycle Services:** Manage filtering, selection, mapping, and permission checks across `BreakService`, `BreakSearchService`, `BreakSelectionService`, `BreakAccessService`, and `BreakMapper`.
+- **Export Services:** `ExportService` and `ExportJobService` manage Excel template rendering and asynchronous job orchestration.
+- **Workflow & Activity:** `SystemActivityService` captures `SystemEventType` entries for runs, approvals, configuration changes, and exposes feeds via `SystemActivityController`.
+- **Ingestion:** `service/ingestion` defines adapters (`CsvIngestionAdapter`, `OpenAiDocumentIngestionAdapter`) and orchestration (`SourceIngestionService`) to normalize inbound data before the matching engine consumes it.
+- **Admin Services:** `service/admin/*` maintain reconciliation metadata, transformation scripts, and group assignments with maker/checker enforcement.
+- **AI Integrations:** `service/ai` encapsulates GPT-based document enrichment or explanation hints to keep external dependencies isolated.
+
+### 3.3 Persistence Layer
+- **Repositories:** Located under `repository`, use Spring Data JPA to query MariaDB/H2. Custom queries power break search pagination and analytics.
+- **Transformations:** Scripts and registries in `service/transform` and `domain/transform` support metadata-driven data normalization.
+- **Configuration:** `src/main/resources` stores `application.yml`, liquibase scripts (if present), LDAP seeds, and ETL templates.
+
+### 3.4 Security
+- **Authentication:** `AuthController` exchanges credentials for JWTs. `UserDirectoryService` integrates with LDAP/LDIF fixtures for development.
+- **Authorization:** `UserContext` holds user identity and group DNs; services validate roles (maker/checker) before performing actions.
+- **Guards:** Method-level checks and `AccessDeniedException` guard sensitive operations, mirrored in the UI guard/route restrictions.
+
+### 3.5 Testing
+- **Unit & Integration Tests:** `backend/src/test/java` includes Spring Boot tests for controllers, services, and repositories.
+- **Harness Debugging:** `controller/harness/HarnessDebugController` assists automation and AI sandbox flows.
+
+## 4. Frontend Architecture (Angular 17)
+
+### 4.1 Composition
+- **Standalone Components:** Located under `frontend/src/app/components`, providing modular building blocks (reconciliation list, run detail, result grid, break detail, checker queue, system activity, admin console, login).
+- **Routing:** `app.routes.ts` orchestrates route-level code splitting and guards to enforce authentication and admin privileges.
+- **State Management:** Services such as `ReconciliationStateService`, `ResultGridStateService`, and `AdminReconciliationStateService` expose RxJS observables representing server state.
+- **Styling:** Angular Material with shared SCSS tokens defined in `frontend/src/styles.*` ensures UI consistency.
+
+### 4.2 Data Flow
+1. `SessionService` stores JWT tokens; `AuthInterceptor` injects them into HTTP requests.
+2. `ApiService` functions call backend endpoints and return typed observables.
+3. State services combine results into view models consumed by components.
+4. Components emit user interactions (filters, run triggers, approvals) back to state services, which invoke additional API calls.
+5. Notifications are displayed using `NotificationService` for success/error events.
+
+### 4.3 Testing & Tooling
+- Jasmine/Karma specs reside alongside components/services (`*.spec.ts`).
+- `npm test -- --watch=false --browsers=ChromeHeadless` executes the suite in CI.
+- Playwright automation (see section 6) performs end-to-end validation of the compiled frontend against the backend.
+
+## 5. Data & Integration Architecture
+
+### 5.1 Data Model
+- **Reconciliation Definitions:** Metadata describing sources, match keys, tolerances, workflows, and UI presentation.
+- **Reconciliation Runs:** Capture execution metadata, counts, and link to break items.
+- **Break Items:** Represent unmatched or mismatched records with detailed attributes, workflow state, comments, and audit history.
+- **Activity Events:** Structured, immutable records enumerating significant actions for audit and observability.
+- **Export Jobs:** Track asynchronous file generation status and metadata for downloads.
+
+### 5.2 Ingestion Lifecycle
+1. Source files arrive via CLI or integration harness.
+2. Ingestion adapters validate schema, enrich data (optionally via AI), and persist to staging tables.
+3. Matching engine pulls metadata and staged data to produce run output.
+4. Breaks are persisted; analytics computed; system events recorded.
+5. Optional downstream exports or notifications triggered based on run outcome.
+
+### 5.3 External Integrations
+- **Schedulers / RPA:** Trigger runs through `/api/reconciliations/{id}/run` using service accounts.
+- **Kafka Hooks:** `service/system` (placeholder) can publish run completion events to event streams (illustrated in diagrams, extendable through adapters).
+- **Observability:** Activity feed and metrics integrate with enterprise APM/SIEM solutions via structured events and log shipping.
+
+## 6. Automation & Quality Gates
+- **Playwright Smoke Tests:** `automation/regression` builds backend/frontend, launches stack, and validates critical UI workflows. `scripts/prepare.mjs` handles orchestration.
+- **Seed Validation:** `scripts/seed-historical.sh` and `scripts/verify-historical-seed.sh` load multi-day datasets to catch performance regressions.
+- **Examples Harness:** `examples/integration-harness/scripts/run_multi_example_e2e.sh` provisions canonical reconciliations and executes end-to-end flows, useful for demos or regression testing.
+- **CI Expectations:** Backend `./mvnw test`, frontend `npm test`, automation `npm test`, plus seed scripts comprise the standard PR checklist.
+
+## 7. Deployment Topology
+
+```mermaid
+graph TD
+  subgraph Edge
+    WAF[Web Application Firewall]
+    LB[Internal Load Balancer]
+  end
+  subgraph Application Tier
+    CDN[CDN / Static Hosting]
+    Pods[Spring Boot Pods]
+  end
+  subgraph Data & Identity
+    Primary[(MariaDB Primary)]
+    Replica[(MariaDB Replica)]
+    LDAPDir[(LDAP / LDAPS)]
+  end
+
+  Users -->|HTTPS| WAF --> LB --> CDN
+  CDN --> Pods
+  Pods --> Primary
+  Primary --> Replica
+  Pods --> LDAPDir
+```
+
+### Deployment Notes
+- Angular assets are built once and deployed to CDN/edge caches; API traffic remains internal behind the load balancer.
+- Stateful services (MariaDB, LDAP) run on protected subnets with automated backups and read replicas for analytics/offloading reporting queries.
+- Feature flags and configuration reside in the database, reducing environment-specific branching.
+
+## 8. Operational Considerations
+- **Logging:** Structured logs emitted from controllers/services include correlation IDs and run identifiers to trace workflows.
+- **Monitoring:** System activity events feed dashboards showing run frequency, break volume, approval throughput, and export status.
+- **Disaster Recovery:** Seed scripts and example payloads provide rapid data reconstruction for lower environments.
+- **Security:** JWT expiry, LDAP sync jobs, and admin guard rails ensure compliance with enterprise governance.
+
+## 9. Documentation & Knowledge Management
+- Authoritative documentation is centralized in `docs/wiki`. Key entry points include the onboarding guide, development workflow, database schema, and this architecture overview.
+- ADR-style records for major changes are summarized in [`DECISIONS.md`](DECISIONS.md) and expanded in dedicated ADR files when applicable.
+
+This architecture reference should be consulted before introducing new features or refactoring existing modules to ensure consistency with platform design principles.

--- a/docs/wiki/COMPONENTS.md
+++ b/docs/wiki/COMPONENTS.md
@@ -1,0 +1,85 @@
+# Component Catalog
+
+The Universal Reconciliation Platform is composed of backend services, a modular analyst UI, automation harnesses, and supporting tooling. This catalog documents the key building blocks, their responsibilities, and example interactions so feature teams can onboard quickly.
+
+## Backend Services (Spring Boot)
+
+| Component | Location | Responsibilities | Usage Example |
+| --- | --- | --- | --- |
+| `UniversalReconciliationPlatformApplication` | `backend/src/main/java/com/universal/reconciliation/UniversalReconciliationPlatformApplication.java` | Boots the Spring application context and enables async execution for non-blocking workflow steps. | Start the service with `./mvnw spring-boot:run` to expose the REST APIs on port 8080. |
+| Controllers | `backend/src/main/java/com/universal/reconciliation/controller` | Surface REST endpoints for reconciliation runs, approvals, break actions, exports, authentication, saved views, and system activity feeds. | Trigger a run: `POST /api/reconciliations/{id}/run` with optional `TriggerRunRequest` payload to kick off metadata-driven matching. |
+| `ReconciliationService` | `backend/src/main/java/com/universal/reconciliation/service/ReconciliationService.java` | Orchestrates run execution, enforces access control, persists runs and breaks, computes analytics, and emits audit events. | Used by `ReconciliationController` to create a run and return `RunDetailDto` for UI dashboards. |
+| Matching Engine | `backend/src/main/java/com/universal/reconciliation/service/matching` | Applies metadata-driven rules to staged data, generates break candidates, and aggregates matched/mismatched counts. | `MatchingEngine.execute(ReconciliationDefinition)` returns a `MatchingResult` consumed during run creation. |
+| Break Management Services | `backend/src/main/java/com/universal/reconciliation/service/BreakService.java`, `backend/src/main/java/com/universal/reconciliation/service/BreakSelectionService.java`, `backend/src/main/java/com/universal/reconciliation/service/BreakAccessService.java`, `backend/src/main/java/com/universal/reconciliation/service/BreakMapper.java` | Manage break lifecycle transitions, enforce maker/checker permissions, materialize grid rows, and convert JPA entities into DTOs. | The UI invokes `PATCH /api/breaks/{id}` to update status; service validates role via `BreakAccessService`. |
+| Search Services | `backend/src/main/java/com/universal/reconciliation/service/BreakSearchService.java`, `backend/src/main/java/com/universal/reconciliation/service/search/*` | Build dynamic SQL predicates, paginate results, and construct metadata describing columns and filters. | `GET /api/reconciliations/{id}/results` returns rows and `BreakSearchPageInfoDto` for infinite scrolling grids. |
+| Export Services | `backend/src/main/java/com/universal/reconciliation/service/ExportService.java`, `backend/src/main/java/com/universal/reconciliation/service/ExportJobService.java`, `backend/src/main/java/com/universal/reconciliation/service/export/*` | Generate Excel extracts from templates, queue export jobs, and stream files back via `/api/exports/{id}` endpoints. | Schedule asynchronous export: `POST /api/exports/{definitionId}` returns a job ID polled by the UI. |
+| Workflow & Activity | `backend/src/main/java/com/universal/reconciliation/service/SystemActivityService.java`, `backend/src/main/java/com/universal/reconciliation/domain/enums/SystemEventType.java`, `backend/src/main/java/com/universal/reconciliation/controller/SystemActivityController.java` | Persist structured activity events for reconciliation runs, approvals, and configuration changes; expose feeds for observability. | `GET /api/system-activity` streams the latest 200 events to populate the analyst activity pane. |
+| Ingestion Services | `backend/src/main/java/com/universal/reconciliation/service/ingestion` | Normalize data feeds by delegating to adapters (`CsvIngestionAdapter`, `OpenAiDocumentIngestionAdapter`), then persist to staging tables. | `SourceIngestionService.ingest(IngestionAdapterRequest)` is invoked by admin workflows or CLI tooling to load source files. |
+| Admin APIs | `backend/src/main/java/com/universal/reconciliation/controller/admin/*`, `backend/src/main/java/com/universal/reconciliation/service/admin/*`, `backend/src/main/java/com/universal/reconciliation/repository/*` | Maintain reconciliation definitions, transformation scripts, access control entries, and user groups. | `PUT /api/admin/reconciliations/{id}` updates metadata; the `AdminReconciliationController` validates maker-checker requirements. |
+| Security Layer | `backend/src/main/java/com/universal/reconciliation/security/*` | Authenticate via LDAP/JWT, populate `UserContext`, and enforce role checks throughout services. | Incoming requests supply JWT tokens; `UserContext` exposes user/group info to controller methods. |
+| Persistence Layer | `backend/src/main/java/com/universal/reconciliation/domain/entity/*`, `backend/src/main/java/com/universal/reconciliation/repository/*` | Define JPA entities for reconciliations, runs, breaks, approvals, exports, and metadata; repositories provide data access. | `ReconciliationRunRepository.findTopByDefinitionOrderByRunDateTimeDesc` fetches latest run for dashboards. |
+| Utilities | `backend/src/main/java/com/universal/reconciliation/util/*`, `backend/src/main/java/com/universal/reconciliation/etl/*` | Provide CSV helpers, transformation registries, sample ETL blueprints, and integration with the ingestion SDK. | Admin UI references the ETL registry to preview available pipelines during onboarding. |
+
+## Frontend (Angular 17)
+
+| Component | Location | Responsibilities | Usage Example |
+| --- | --- | --- | --- |
+| Root Shell | `frontend/src/app/app.component.*` | Hosts global layout, navigation, notification toasts, and router outlet. | Boot via `npm start` to serve `http://localhost:4200` for local development. |
+| Routing | `frontend/src/app/app.routes.ts` | Declares standalone route configuration for login, reconciliation workspace, admin console, and deep-linked run views. | `[{ path: 'reconciliations/:id', loadComponent: () => import('./components/run-detail/run-detail.component') }]`. |
+| Auth Components | `components/login` | Manage credential capture, token exchange, and redirect to last location using `SessionService`. | When JWT expires, `AuthInterceptor` refreshes and re-routes to `/login`. |
+| Analyst Workspace | `components/analyst-workspace` | Aggregate reconciliation list, run summary, result grid, break detail drawer, and checker queue panes into a responsive layout. | Handles `RunDetailDto` responses to synchronize grid filters and break details. |
+| Reconciliation List | `components/reconciliation-list` | Presents accessible definitions via cards and emits selection events. | Binds to `ReconciliationStateService.reconciliations$`. |
+| Run Detail | `components/run-detail` | Displays run summary cards, analytics charts, and trigger controls; emits filter selections to result grid. | Calls `ApiService.triggerRun(id, payload)` when analysts start manual runs. |
+| Result Grid | `components/result-grid` | Renders paginated break records, infinite scroll, column definitions, and bulk selection using CDK virtual scroll. | Consumes `BreakSearchResponseDto` to stream 50-row pages. |
+| Break Detail Drawer | `components/break-detail` | Shows contextual metadata, comments, and maker/checker actions for selected break items. | Invokes `ApiService.updateBreakStatus` with approval notes. |
+| Checker Queue | `components/checker-queue` | Summarizes approvals awaiting checker review, limited by `app.approvals.queue-size`. | Subscribes to `ReconciliationStateService.approvalQueue$`. |
+| System Activity Timeline | `components/system-activity` | Streams and renders `SystemEventDto` entries for transparency and audit. | Uses `ApiService.fetchSystemActivity` to load the feed on workspace initialization. |
+| Admin Console | `components/admin/*` | Wizard-driven experience for maintaining definitions, transformations, and access control. | `AdminReconciliationStateService` caches drafts prior to publishing changes. |
+| Services | `frontend/src/app/services` | Provide API bindings, application state stores, notification facade, and auth guard. | `ReconciliationStateService` composes multiple HTTP calls into reactive state for the analyst workspace. |
+| Models | `frontend/src/app/models` | TypeScript interfaces mirroring backend DTOs for type-safe data binding. | `RunDetail` interface aligns with `RunDetailDto` schema. |
+
+## Shared Libraries
+
+| Library | Location | Description | Usage |
+| --- | --- | --- | --- |
+| Ingestion SDK | `libraries/ingestion-sdk` | Java toolkit that abstracts CSV ingestion, metadata validation, and CLI helpers. Bundled with scripts to package a runnable ingestion CLI. | Used by `examples/integration-harness` and admin workflows to load sample data sets into staging tables. |
+| Frontend Shared Styles | `frontend/src/styles.*` (global) | Provide theming, typography, and spacing tokens aligning with enterprise design system. | Imported into Angular components via SCSS mixins. |
+| Example Payloads | `examples/common`, `examples/*/payloads` | Seed files, transformation scripts, and run harnesses for canonical reconciliations. | Execute `examples/integration-harness/scripts/run_multi_example_e2e.sh` to provision and validate all examples. |
+
+## Automation & Quality Gates
+
+| Asset | Location | Purpose | Usage |
+| --- | --- | --- | --- |
+| Playwright Smoke Suite | `automation/regression` | Installs backend/frontend, launches stack, and runs end-to-end UI journeys. Includes fixtures for sample data. | `cd automation/regression && npm install && npm test`. |
+| Maven Tests | `backend` | JUnit + Spring Boot tests covering services, repositories, and controllers. | `cd backend && ./mvnw test`. |
+| Frontend Unit Tests | `frontend` | Jasmine/Karma specs for components and state services. | `cd frontend && npm test -- --watch=false --browsers=ChromeHeadless`. |
+| Seed Scripts | `scripts/local-dev.sh` | Bootstraps dependencies and seeds historical data via CLI. | `./scripts/local-dev.sh bootstrap && ./scripts/local-dev.sh seed`. |
+
+## Infrastructure & Operations
+
+| Component | Location | Description | Usage |
+| --- | --- | --- | --- |
+| Docker Compose | `infra/docker-compose.yml` | Spins up MariaDB, LDAP, and supporting services for local development. | `docker-compose up` from the `infra` directory. |
+| LDAP Fixtures | `infra/ldap` | Contains LDIF seeds representing enterprise groups used by `UserContext`. | Loaded automatically by `docker-compose` to provision sample users. |
+| Historical Seed Scripts | `scripts/seed-historical.sh`, `scripts/verify-historical-seed.sh` | Populate and validate large data sets for performance testing. | Run with `--days 3 --runs-per-day 1 --skip-export-check` to mirror CI coverage. |
+
+## Documentation Hub
+
+| Resource | Location | Description |
+| --- | --- | --- |
+| Wiki Home | `docs/wiki/README.md` | Navigation entry point covering onboarding, development workflow, and feature overviews. |
+| Getting Started | `docs/wiki/Getting-Started.md` | Step-by-step guide for setting up the local stack, running tests, and seeding data. |
+| Architecture Briefing | `docs/wiki/Architecture-Review-Briefing.md` | Executive-level summary of platform capabilities and roadmap. |
+| Database Schema | `docs/wiki/Database-Schema.md` | Entity relationship diagrams and table descriptions for reconciliation metadata, runs, and workflow artifacts. |
+
+## Example End-to-End Flow
+
+1. **Admin Configures** a reconciliation using the Angular admin console, storing metadata via `AdminReconciliationController`.
+2. **Ingestion CLI** (powered by the ingestion SDK) loads source files using `SourceIngestionService` and writes staged records.
+3. **Analyst Triggers** a run from the UI (`RunDetailComponent`), which calls `POST /api/reconciliations/{id}/run` and displays streaming analytics.
+4. **Breaks Appear** in the result grid; analysts drill down via the break detail drawer and add comments.
+5. **Checker Reviews** the approval queue, transitions breaks to `APPROVED`, and the system logs activity events.
+6. **Exports** are requested by the analyst (`ExportController`), generating Excel files accessible via the UI download center.
+7. **Automation Suite** runs nightly Playwright scenarios to verify critical journeys, while historical seed scripts ensure data volume scenarios stay healthy.
+
+This catalog should serve as the definitive reference when navigating or extending the platform.

--- a/docs/wiki/DECISIONS.md
+++ b/docs/wiki/DECISIONS.md
@@ -1,0 +1,65 @@
+# Decision Log
+
+This page summarizes the architectural and process decisions that govern the Universal Reconciliation Platform. Each entry captures the context, the chosen approach, and the implications for future work. When a decision requires deeper discussion, link to the dedicated ADR file.
+
+## D-001: Spring Boot Monolith with Modular Boundaries
+- **Context:** Initial releases needed rapid iteration while supporting future decomposition.
+- **Decision:** Implement a single Spring Boot application (`UniversalReconciliationPlatformApplication`) with package-level separation for controllers, services, domain entities, and adapters.
+- **Rationale:** A monolith minimizes deployment overhead while allowing teams to extract modules later thanks to clean service interfaces (e.g., matching, exports, ingestion).
+- **Implications:** Keep inter-service communication via method calls/interfaces rather than shared state; avoid cyclic dependencies between packages to ease eventual microservice extraction.
+
+## D-002: Metadata-Driven Matching & UI Configuration
+- **Context:** Business teams frequently onboard new reconciliations with varying match keys, tolerances, and workflows.
+- **Decision:** Store reconciliation definitions, workflows, and grid metadata in MariaDB via entities under `domain/entity` and serve them through DTOs.
+- **Rationale:** Metadata allows new reconciliations to be deployed without code changes, aligning with the configuration-over-code principle.
+- **Implications:** Any new feature must include metadata schema updates and admin console support; tests must seed representative metadata before execution.
+
+## D-003: Angular 17 Standalone Components
+- **Context:** The analyst UI required fast navigation, modular widgets, and a design system aligned with Angular Material.
+- **Decision:** Use Angular 17 with standalone components (`frontend/src/app/components`) and route-level lazy loading defined in `app.routes.ts`.
+- **Rationale:** Standalone components reduce NgModule boilerplate, making it easier to share UI primitives across the workspace and admin console.
+- **Implications:** Maintain pure presentational components where possible and keep stateful logic in services (`ReconciliationStateService`, `ResultGridStateService`).
+
+## D-004: Playwright-Based Automation Harness
+- **Context:** Regression coverage needed to span backend, frontend, and ingestion flows in a realistic environment.
+- **Decision:** Build a Playwright smoke suite (`automation/regression`) that prepares both backend and frontend, seeds data, and exercises end-to-end scenarios.
+- **Rationale:** Playwright provides cross-browser coverage with rich debugging artifacts while enabling headless CI execution.
+- **Implications:** Changes to critical workflows must include Playwright updates; `npm test` in the automation directory becomes part of the PR checklist.
+
+## D-005: Shared Ingestion SDK for CLI & Backend
+- **Context:** Ingestion logic was duplicated between the platform and standalone examples, causing drift.
+- **Decision:** Extract ingestion utilities into `libraries/ingestion-sdk`, consumed by backend services and CLI scripts.
+- **Rationale:** A shared SDK enforces consistent validation, transformation, and error handling.
+- **Implications:** New ingestion features must land in the SDK first, then be referenced by backend/CLI; semantic versioning of the SDK is required for external consumers.
+
+## D-006: LDAP + JWT Security Model
+- **Context:** Enterprise deployments require integration with corporate directories and auditable session handling.
+- **Decision:** Authenticate against LDAP (with LDIF fixtures for dev) and issue JWTs consumed by the Angular app via `AuthInterceptor`.
+- **Rationale:** Keeps identity management external while enabling stateless API servers.
+- **Implications:** Route guards and service methods must validate maker/checker permissions based on LDAP group DNs. Token refresh/expiry policies must stay aligned with enterprise standards.
+
+## D-007: System Activity Feed as Audit Backbone
+- **Context:** Audit teams needed detailed, immutable timelines of reconciliation events.
+- **Decision:** Persist structured system activity entries (`SystemActivityService`, `domain/enums/SystemEventType`) and expose them through `/api/system-activity` for UI dashboards and downstream observability.
+- **Rationale:** Centralized event storage simplifies compliance reporting and incident investigations.
+- **Implications:** Any new action with audit relevance must emit a `SystemEventType`. Events should include correlation IDs to trace runs, breaks, and exports.
+
+## D-008: Maker/Checker Enforcement in Admin Workflows
+- **Context:** Configuration changes must undergo dual control.
+- **Decision:** Require access control entries and admin services (`service/admin/*`) to validate maker/checker roles before persisting metadata updates.
+- **Rationale:** Embedding governance into services and the Angular admin console prevents policy violations.
+- **Implications:** Admin UI must surface draft vs. published states; automated tests should verify that checkers cannot self-approve their own changes.
+
+## D-009: Historical Seed Scripts for Scale Testing
+- **Context:** Need to validate performance across large time windows and run volumes.
+- **Decision:** Maintain shell scripts (`scripts/seed-historical.sh`, `scripts/verify-historical-seed.sh`) that generate multi-day datasets and run verification queries.
+- **Rationale:** Keeps non-functional testing reproducible without manual database setup.
+- **Implications:** Feature teams must update seed scripts when schema changes affect historical data; CI may run lighter variants during PR validation.
+
+## D-010: Documentation-First Knowledge Base
+- **Context:** Complex workflows span backend, frontend, ingestion, and automation.
+- **Decision:** Centralize living documentation under `docs/wiki` with specialized guides (architecture, components, onboarding, development workflow, API reference).
+- **Rationale:** Reduces ramp-up time for new contributors and provides a single source of truth for product, engineering, and operations.
+- **Implications:** Every change affecting behavior must include wiki updates; PR templates should call out documentation impact.
+
+Refer to this log when proposing new features to ensure alignment with past decisions and to identify whether a new ADR is required.

--- a/docs/wiki/MILESTONES.md
+++ b/docs/wiki/MILESTONES.md
@@ -1,0 +1,71 @@
+# Development Milestones & Lessons Learned
+
+This timeline captures the major phases that shaped the Universal Reconciliation Platform. Each milestone highlights the features delivered, supporting artifacts within this repository, and key lessons that continue to influence engineering practices.
+
+## Phase 0 – Charter & Bootstrap (Month 0)
+- **Highlights:** Drafted the product charter, captured scope in `docs/Bootstrap.md`, and defined the metadata-first philosophy for reconciliation onboarding.
+- **Key Assets:** Infrastructure scaffolding under `infra/`, historical context in `docs/Bootstrap.md`.
+- **Lessons Learned:** Align early on configuration-driven principles to avoid brittle feature flags later. Establish documentation expectations from day one to keep wiki artifacts authoritative.
+
+## Phase 1 – Foundational Monolith (Months 1-2)
+- **Highlights:**
+  - Established the Spring Boot monolith entry point (`UniversalReconciliationPlatformApplication`) with async support.
+  - Created baseline domain entities and repositories covering reconciliations, runs, breaks, approvals, and exports (`backend/src/main/java/com/universal/reconciliation/domain`).
+  - Implemented authentication/authorization via LDAP-integrated `security` module and JWT propagation (`backend/src/main/java/com/universal/reconciliation/security`).
+- **Key Assets:** Backend `pom.xml`, `ReconciliationController`, `AuthController`, initial unit tests.
+- **Lessons Learned:** Modeling maker/checker roles in entities early simplified later workflow features; securing controllers with `UserContext` reduced retrofitting costs.
+
+## Phase 2 – Matching Engine & Ingestion (Months 3-4)
+- **Highlights:**
+  - Delivered the metadata-driven matching engine (`service/matching`) that produces `MatchingResult` artifacts used by `ReconciliationService`.
+  - Added ingestion adapters (`service/ingestion`) and the standalone ingestion SDK (`libraries/ingestion-sdk`) to normalize CSVs and AI-enriched documents.
+  - Wired in ETL blueprints under `backend/src/main/java/com/universal/reconciliation/etl` and example payloads in `examples/common`.
+- **Key Assets:** `SourceIngestionService`, `CsvIngestionAdapter`, ingestion CLI scripts, integration harness.
+- **Lessons Learned:** Adapters with a uniform `IngestionAdapterRequest` contract accelerated onboarding of new sources. Keeping ingestion logic in a shared SDK prevented drift between CLI and backend behaviors.
+
+## Phase 3 – Analyst Workspace Experience (Months 5-6)
+- **Highlights:**
+  - Built the Angular analyst workspace with standalone components for reconciliation list, run detail, result grid, break drawer, and system activity (`frontend/src/app/components`).
+  - Created reactive state services (`ReconciliationStateService`, `ResultGridStateService`) to orchestrate API calls and UI synchronization.
+  - Implemented break search pagination and selection APIs (`BreakSearchService`, `BreakSelectionService`).
+- **Key Assets:** Angular routes, Material-based UI components, TypeScript models mirroring backend DTOs.
+- **Lessons Learned:** Co-locating API bindings and state logic in services improved testability; providing cursor-based pagination from day one avoided grid rework.
+
+## Phase 4 – Workflow Automation & Exports (Months 7-8)
+- **Highlights:**
+  - Introduced approval queue APIs (`ReconciliationService.fetchApprovalQueue`) and checker dashboard components.
+  - Added export job orchestration (`ExportJobService`, `/api/exports`) delivering Excel files, plus Playwright coverage to validate downloads.
+  - Expanded system activity stream capturing run triggers, approvals, and configuration changes (`SystemActivityService`).
+- **Key Assets:** `components/checker-queue`, `components/system-activity`, backend export services, Playwright smoke tests.
+- **Lessons Learned:** Recording structured system events simplified audit requirements; asynchronous exports keep API latencies predictable under high volume.
+
+## Phase 5 – Admin Console & Metadata Governance (Months 9-10)
+- **Highlights:**
+  - Delivered admin-facing Angular workflows for maintaining definitions, transformations, and access control (`components/admin`, `AdminReconciliationStateService`).
+  - Hardened repositories and services to enforce maker/checker governance across configuration changes (`service/admin/*`).
+  - Embedded ingestion SDK guidance directly into the wiki (`docs/wiki/ingestion-sdk.md`).
+- **Key Assets:** Admin controllers, shared DTOs, onboarding tutorial.
+- **Lessons Learned:** Drafting metadata changes on the client before publishing prevents partial updates; validating LDAP groups up front reduces runtime support incidents.
+
+## Phase 6 – Observability & Historical Scale (Months 11-12)
+- **Highlights:**
+  - Added historical seed scripts (`scripts/seed-historical.sh`, `scripts/verify-historical-seed.sh`) to simulate large volumes and verify run analytics.
+  - Extended automation harness to launch full stack and execute Playwright flows (`automation/regression/scripts/prepare.mjs`).
+  - Streamlined documentation navigator and database schema diagrams in the wiki for operational readiness.
+- **Key Assets:** Automation reports under `automation/regression/reports`, wiki navigator, database diagrams.
+- **Lessons Learned:** Automating heavy data seeds catches performance regressions early; bundling documentation with tooling reduces tribal knowledge risk.
+
+## Phase 7 – AI-Assisted Operations (Ongoing)
+- **Highlights:**
+  - Integrated AI services for document ingestion and break explanation hints (`service/ai`).
+  - Prepared harness debug controller (`controller/harness/HarnessDebugController`) to assist with sandboxing GPT-based flows.
+  - Documented AI usage considerations in the onboarding guide.
+- **Key Assets:** `OpenAiDocumentIngestionAdapter`, AI service classes, harness debugging endpoints.
+- **Lessons Learned:** Keep AI interactions behind adapters for easy swapping; capture explainability metadata to satisfy audit teams.
+
+## Continuing Investments
+- **Documentation:** Every release updates the wiki knowledge base (including this milestone record) to keep product, engineering, and operations aligned.
+- **Testing:** CI gates run backend, frontend, automation, and seed scripts to ensure parity across touchpoints.
+- **Governance:** Decisions are logged in `docs/wiki/DECISIONS.md`, and architectural updates cascade through `ARCHITECTURE.md` and database diagrams.
+
+Use this chronology to understand how the platform evolved and which artifacts to reference when extending its capabilities.

--- a/docs/wiki/PATTERNS.md
+++ b/docs/wiki/PATTERNS.md
@@ -1,0 +1,80 @@
+# Coding Patterns & Conventions
+
+This guide describes the recurring patterns used across the Universal Reconciliation Platform. Following these conventions keeps codebases consistent and eases onboarding for new contributors.
+
+## Backend (Spring Boot)
+
+### Dependency Injection & Constructors
+- Prefer constructor injection for all services, controllers, and components (see `ReconciliationService`, `ReconciliationController`).
+- Avoid field injection; this improves testability and enforces immutability for dependencies.
+
+### DTO Mapping
+- DTOs live under `domain/dto` and are immutable records when possible. Services convert entities to DTOs using dedicated mappers (e.g., `BreakMapper`).
+- Controllers should never expose entities directly; always return DTOs to maintain a stable API contract.
+
+### Service Responsibilities
+- Keep services cohesive: `ReconciliationService` orchestrates runs, `BreakSearchService` handles search/pagination, `ExportService` manages file generation.
+- Cross-cutting concerns (access control, analytics, activity logging) are encapsulated in helper services injected where needed.
+
+### Repository Usage
+- Use Spring Data JPA repositories for common queries and define custom methods when performance requires it. For example, `ReconciliationRunRepository.findTopByDefinitionOrderByRunDateTimeDesc` drives dashboard views.
+- When pagination or filtering logic grows complex, push it into dedicated search services (`service/search`) rather than embedding query logic inside controllers.
+
+### Validation & Error Handling
+- Validate inputs using Jakarta validation annotations on DTOs and method parameters. `RestExceptionHandler` centralizes translation of exceptions into HTTP responses.
+- Throw domain-specific exceptions (e.g., `AccessDeniedException`, `IllegalArgumentException`) with meaningful messages for UI display.
+
+### Logging & Activity
+- Emit structured system events through `SystemActivityService`. Log correlation IDs for runs and breaks to aid troubleshooting.
+- Use SLF4J loggers sparingly in services; prefer the structured activity feed for audit trails.
+
+### Testing
+- Write Spring Boot tests in `backend/src/test/java` using `@SpringBootTest` or slice annotations as appropriate.
+- Mock external dependencies (e.g., AI adapters) via interfaces to keep tests deterministic.
+
+## Frontend (Angular 17)
+
+### Standalone Components & Module-Free Design
+- Build components as standalone to leverage Angular 17 features. Import Material modules directly within component definitions.
+- Organize components by feature (`components/run-detail`, `components/result-grid`) and keep styling in component-scoped CSS/SCSS files.
+
+### Reactive State Management
+- Encapsulate API calls and derived state in services (`ReconciliationStateService`, `ResultGridStateService`, `AdminReconciliationStateService`).
+- Expose read-only observables (`Observable<T>`) to components; trigger updates via explicit methods (e.g., `loadRun(id)`).
+
+### HTTP & Authentication
+- Use `ApiService` as the single integration point for backend HTTP calls. Keep request/response interfaces in `frontend/src/app/models`.
+- `AuthInterceptor` attaches JWT tokens automatically; components should not manipulate headers directly.
+
+### UI Interaction Patterns
+- Use Angular Material tables and CDK virtual scrolling for large datasets (as implemented in `components/result-grid`).
+- For modal/drawer interactions, maintain local component state and emit events upward to parent components (`breakSelected`, `filterChanged`).
+- Surface notifications via `NotificationService` to ensure consistent toast styling and accessibility.
+
+### Testing
+- Store `.spec.ts` alongside each component/service. Use `TestBed` with standalone component configuration.
+- Mock services using Angular dependency injection; verify DOM interactions and observable emissions.
+
+## Automation & Tooling
+
+### Playwright Tests
+- Keep Playwright tests in `automation/regression/tests`; share fixtures via `tests/fixtures` to avoid duplication.
+- Use the provided `scripts/prepare.mjs` to build backend/frontend before running tests locally or in CI.
+- Capture screenshots and traces for failures; commit updates to fixtures when UI or workflows change intentionally.
+
+### Seed & Example Scripts
+- Standardize CLI usage via scripts under `scripts/` and `examples/integration-harness/scripts`. These scripts are part of the required validation checklist.
+- Update both scripts and wiki documentation whenever new reconciliation examples are added.
+
+## Documentation Practices
+- Every feature touching behavior must reference or update the relevant wiki page (e.g., onboarding, API reference, this pattern guide).
+- Use Mermaid diagrams for flows; keep file paths relative when linking inside the wiki.
+
+## Code Review Checklist
+- Ensure dependency injection follows conventions (constructor-based).
+- Confirm DTOs shield internal entities from API consumers.
+- Verify access control checks exist for maker/checker-sensitive operations.
+- Update Playwright and seed scripts as needed.
+- Include automated test updates and run results in PRs.
+
+Adhering to these patterns ensures code remains maintainable, testable, and compliant with platform governance.

--- a/docs/wiki/TROUBLESHOOTING.md
+++ b/docs/wiki/TROUBLESHOOTING.md
@@ -1,0 +1,101 @@
+# Troubleshooting Guide
+
+This guide documents common issues encountered while developing or operating the Universal Reconciliation Platform, along with root causes and proven fixes.
+
+## Backend Issues
+
+### Application Fails to Start (Port Already in Use)
+- **Symptoms:** `java.net.BindException: Address already in use` when launching the Spring Boot app.
+- **Cause:** Another service is bound to port 8080.
+- **Resolution:** Stop the conflicting service or override the port using `SERVER_PORT=9090 ./mvnw spring-boot:run`. Update frontend `.env` or proxy config if running locally.
+
+### LDAP Authentication Errors
+- **Symptoms:** Login attempts return 401 with `Invalid credentials` despite using sample users.
+- **Cause:** LDAP container not running or LDIF fixtures not loaded.
+- **Resolution:**
+  1. Start the infrastructure stack via `cd infra && docker-compose up`.
+  2. Verify `ldap` service logs show LDIF import success.
+  3. Re-run backend tests; if using H2 profile, ensure `application-h2.yml` points to the embedded LDIF file.
+
+### Matching Engine Returns Empty Breaks
+- **Symptoms:** Runs complete successfully but no breaks appear despite known differences.
+- **Cause:** Ingestion metadata mismatch (wrong keys, tolerances) or staging tables not seeded.
+- **Resolution:**
+  - Confirm ingestion completed by checking activity feed for `INGESTION_COMPLETED` events.
+  - Review reconciliation definition in admin console; ensure match keys align with source data columns.
+  - Re-run ingestion CLI (`examples/integration-harness/scripts/run_multi_example_e2e.sh` or targeted scripts) to refresh staging data.
+
+### Export Job Stuck in `PENDING`
+- **Symptoms:** UI download center shows pending export indefinitely.
+- **Cause:** Background job executor missing or errors in template rendering.
+- **Resolution:**
+  - Check backend logs for stack traces from `ExportService`.
+  - Ensure `app.export.template-dir` property points to valid templates under `src/main/resources`.
+  - Re-run export after fixing template issues; stuck jobs can be cleared by deleting rows from `export_job` table in non-prod environments.
+
+## Frontend Issues
+
+### HTTP 401 After Login
+- **Symptoms:** UI redirects to `/login` immediately after authentication.
+- **Cause:** `AuthInterceptor` failed to attach JWT because `SessionService` storage is empty or browser blocked cookies/localStorage.
+- **Resolution:** Clear browser storage, log in again, ensure backend `/api/auth/login` returns `token` field. In dev mode, verify proxy configuration forwards `/api` to correct backend port.
+
+### Infinite Spinner on Result Grid
+- **Symptoms:** Grid displays loading indicator without data.
+- **Cause:** Break search request failed; often due to invalid filters or backend error.
+- **Resolution:**
+  - Open browser dev tools, inspect network call to `/api/reconciliations/{id}/results`.
+  - If 400, reset filters in UI; if 500, review backend logs for query errors.
+  - Ensure metadata definitions include column configurations so the grid can render headers.
+
+### Angular Build Failures
+- **Symptoms:** `ng build` fails with missing module or type errors.
+- **Cause:** TypeScript interfaces not updated after backend DTO change.
+- **Resolution:** Update models under `frontend/src/app/models`, regenerate API typings if using OpenAPI, and run `npm test` to validate.
+
+## Ingestion & Examples
+
+### Ingestion CLI Cannot Connect to Database
+- **Symptoms:** CLI errors with `Communications link failure` when seeding examples.
+- **Cause:** Database container not running or incorrect JDBC URL.
+- **Resolution:** Ensure Docker Compose stack is up, confirm JDBC settings in `examples/integration-harness/application.properties`, and re-run the CLI.
+
+### OpenAI Adapter Timeouts
+- **Symptoms:** `OpenAiDocumentIngestionAdapter` throws timeout exceptions during ingestion.
+- **Cause:** Missing or invalid API credentials, or rate limiting.
+- **Resolution:** Provide valid API keys via environment variables, configure retry/backoff in adapter properties, or switch to offline CSV ingestion during local development.
+
+## Automation & Testing
+
+### Playwright Suite Fails During Setup
+- **Symptoms:** `npm test` in `automation/regression` fails before tests execute.
+- **Cause:** Dependencies missing or backend/frontend builds failing in prep script.
+- **Resolution:**
+  - Run `npm install` inside `automation/regression` to install Playwright and browsers.
+  - Inspect `automation/regression/scripts/prepare.mjs` logs for backend/frontend build errors and fix underlying issues.
+  - Clean previous builds via `rm -rf automation/regression/tmp` if present.
+
+### Historical Seed Verification Fails
+- **Symptoms:** `scripts/verify-historical-seed.sh` exits non-zero complaining about missing runs.
+- **Cause:** Seed script not executed or environment variables set incorrectly.
+- **Resolution:**
+  - Run `./scripts/seed-historical.sh --days 3 --runs-per-day 1 --skip-export-check`.
+  - Ensure the backend is running during verification so APIs can be queried.
+  - Check database for expected runs; adjust configuration to match local constraints.
+
+## Infrastructure
+
+### Docker Compose Containers Unhealthy
+- **Symptoms:** `docker ps` shows `unhealthy` for `db` or `ldap` services.
+- **Cause:** Resource constraints or incorrect environment variables.
+- **Resolution:**
+  - Increase Docker memory allocation if running out of resources.
+  - Remove existing volumes (`docker-compose down -v`) and restart to regenerate databases.
+  - Confirm `.env` files in `infra/` are aligned with expected credentials.
+
+### Timezone or Locale Mismatches
+- **Symptoms:** Run timestamps differ between UI and database.
+- **Cause:** Backend runs in UTC while frontend expects local timezone.
+- **Resolution:** Ensure frontend converts timestamps using the `runDateTimeZone` provided in `BreakSearchResultRowDto`. Adjust browser locale settings as needed for testing.
+
+Use this guide as the first line of defense when diagnosing issues. If a problem persists, capture relevant logs, command outputs, and environment details before escalating to the platform maintainers.


### PR DESCRIPTION
## Summary
- add a component catalog describing backend, frontend, automation, and infrastructure assets
- document platform milestones, architecture, key decisions, reusable patterns, and troubleshooting guidance

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68dfe82d9470832b9eedef4ceb83ce17