### PR TITLE
Refactor admin configurator around source schema workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ automation/regression/reports/
 .idea/
 .DS_Store
 examples/**/target/
+libraries/ingestion-sdk/target/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Welcome, automated contributor! Follow these ground rules to collaborate effecti
 - **Automation smoke (Playwright):** `cd automation/regression && npm install && npm test`
 - **Examples integration harness:** `examples/integration-harness/scripts/run_multi_example_e2e.sh`
 - **Bootstrap scripts:** `./scripts/local-dev.sh bootstrap` (and `seed` once the stack is running) to confirm local helpers stay healthy.
-- **Historical volume seed:** `./scripts/seed-historical.sh` followed by `./scripts/verify-historical-seed.sh` (use the lighter `--days 3 --runs-per-day 1 --skip-export-check` combo to mirror CI) to ensure large-scale data workflows continue to pass.
+- **Historical volume seed:** `./scripts/seed-historical.sh --days 3 --runs-per-day 1 --report-format NONE --ci-mode` followed by `./scripts/verify-historical-seed.sh --days 3 --runs-per-day 1 --skip-export-check` to mirror the lightweight CI cadence and ensure large-scale data workflows continue to pass.
 - Include command outputs in pull request descriptions when applicable.
 
 ## Automation & E2E Toolkit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,13 +15,6 @@ Welcome, automated contributor! Follow these ground rules to collaborate effecti
 3. **Prefer incremental commits.** Group logically-related changes and provide descriptive commit messages.
 4. **Respect configuration over code.** Extend metadata-driven constructs instead of hardcoding reconciliation behavior.
 5. **Keep test cases up to date.** Any code change that affects features, workflows, or onboarding must update the relevant test cases in backend, frontend, automation smoke, example integration harness, and bootstrap scripts.
-6. **Update knowledgebase in wiki.** Analyze new changes and update following docs for any features, changes or refactor:
-   * **COMPONENTS.md** Component catalog with usage examples
-   * **MILESTONES.md** Development history and lessons learned
-   * **ARCHITECTURE.md** How everything connects and why
-   * **DECISIONS.md** Technical choices and their rationale
-   * **PATTERNS.md** Reusable code patterns and conventions
-   * **TROUBLESHOOTING.md** Common issues and solutions
 
 ## Quality Gates
 - **Backend tests:** `cd backend && ./mvnw test`

--- a/backend/src/main/java/com/universal/reconciliation/controller/admin/AdminSourceSchemaController.java
+++ b/backend/src/main/java/com/universal/reconciliation/controller/admin/AdminSourceSchemaController.java
@@ -1,0 +1,43 @@
+package com.universal.reconciliation.controller.admin;
+
+import com.universal.reconciliation.domain.dto.admin.SourceSchemaInferenceRequest;
+import com.universal.reconciliation.domain.dto.admin.SourceSchemaInferenceResponse;
+import com.universal.reconciliation.service.admin.AdminSourceSchemaService;
+import com.universal.reconciliation.service.transform.TransformationEvaluationException;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * API surface for inferring source schemas from uploaded samples.
+ */
+@RestController
+@RequestMapping("/api/admin/source-schemas")
+@PreAuthorize("hasRole('RECON_ADMIN')")
+public class AdminSourceSchemaController {
+
+    private final AdminSourceSchemaService schemaService;
+
+    public AdminSourceSchemaController(AdminSourceSchemaService schemaService) {
+        this.schemaService = schemaService;
+    }
+
+    @PostMapping(value = "/infer", consumes = {"multipart/form-data"})
+    public SourceSchemaInferenceResponse inferSchema(
+            @Valid @RequestPart("request") SourceSchemaInferenceRequest request,
+            @RequestPart("file") MultipartFile file) {
+        return schemaService.inferSchema(request, file);
+    }
+
+    @ExceptionHandler(TransformationEvaluationException.class)
+    public ResponseEntity<String> handleEvaluationException(TransformationEvaluationException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+}

--- a/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/AdminReconciliationSchemaDto.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/AdminReconciliationSchemaDto.java
@@ -26,7 +26,15 @@ public record AdminReconciliationSchemaDto(
             String arrivalTimezone,
             Integer arrivalSlaMinutes,
             String adapterOptions,
+            List<SchemaSourceFieldDto> schemaFields,
             String ingestionEndpoint) {}
+
+    public record SchemaSourceFieldDto(
+            String name,
+            String displayName,
+            FieldDataType dataType,
+            boolean required,
+            String description) {}
 
     public record SchemaFieldDto(
             String displayName,

--- a/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/AdminSourceDto.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/AdminSourceDto.java
@@ -21,6 +21,7 @@ public record AdminSourceDto(
         Integer arrivalSlaMinutes,
         String adapterOptions,
         SourceTransformationPlan transformationPlan,
+        List<AdminSourceSchemaFieldDto> schemaFields,
         List<String> availableColumns,
         Instant createdAt,
         Instant updatedAt) {}

--- a/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/AdminSourceRequest.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/AdminSourceRequest.java
@@ -4,6 +4,7 @@ import com.universal.reconciliation.domain.enums.IngestionAdapterType;
 import com.universal.reconciliation.domain.transform.SourceTransformationPlan;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 
 /**
  * Source definition used when creating or updating reconciliations.
@@ -20,4 +21,5 @@ public record AdminSourceRequest(
         String arrivalTimezone,
         Integer arrivalSlaMinutes,
         String adapterOptions,
-        SourceTransformationPlan transformationPlan) {}
+        SourceTransformationPlan transformationPlan,
+        List<AdminSourceSchemaFieldRequest> schemaFields) {}

--- a/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/AdminSourceSchemaFieldDto.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/AdminSourceSchemaFieldDto.java
@@ -1,0 +1,13 @@
+package com.universal.reconciliation.domain.dto.admin;
+
+import com.universal.reconciliation.domain.enums.FieldDataType;
+
+/**
+ * Describes a single column within a source schema definition.
+ */
+public record AdminSourceSchemaFieldDto(
+        String name,
+        String displayName,
+        FieldDataType dataType,
+        boolean required,
+        String description) {}

--- a/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/AdminSourceSchemaFieldRequest.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/AdminSourceSchemaFieldRequest.java
@@ -1,0 +1,14 @@
+package com.universal.reconciliation.domain.dto.admin;
+
+import com.universal.reconciliation.domain.enums.FieldDataType;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Payload used when persisting source schema fields via the admin API.
+ */
+public record AdminSourceSchemaFieldRequest(
+        @NotBlank String name,
+        String displayName,
+        FieldDataType dataType,
+        boolean required,
+        String description) {}

--- a/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/SourceSchemaInferenceRequest.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/SourceSchemaInferenceRequest.java
@@ -1,0 +1,21 @@
+package com.universal.reconciliation.domain.dto.admin;
+
+import com.universal.reconciliation.domain.enums.TransformationSampleFileType;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+/**
+ * Describes how an uploaded sample file should be parsed when
+ * inferring source schema metadata.
+ */
+public record SourceSchemaInferenceRequest(
+        @NotNull TransformationSampleFileType fileType,
+        boolean hasHeader,
+        String delimiter,
+        String sheetName,
+        List<String> sheetNames,
+        boolean includeAllSheets,
+        String recordPath,
+        String encoding,
+        Integer limit,
+        Integer skipRows) {}

--- a/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/SourceSchemaInferenceResponse.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/dto/admin/SourceSchemaInferenceResponse.java
@@ -1,0 +1,11 @@
+package com.universal.reconciliation.domain.dto.admin;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Result of inferring a schema from a sample dataset.
+ */
+public record SourceSchemaInferenceResponse(
+        List<AdminSourceSchemaFieldDto> fields,
+        List<Map<String, Object>> sampleRows) {}

--- a/backend/src/main/java/com/universal/reconciliation/domain/entity/ReconciliationSource.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/entity/ReconciliationSource.java
@@ -2,7 +2,9 @@ package com.universal.reconciliation.domain.entity;
 
 import com.universal.reconciliation.domain.enums.IngestionAdapterType;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -13,9 +15,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderColumn;
 import jakarta.persistence.Table;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
@@ -72,6 +77,13 @@ public class ReconciliationSource {
 
     @Column(name = "transformation_plan", columnDefinition = "TEXT")
     private String transformationPlan;
+
+    @ElementCollection
+    @CollectionTable(
+            name = "reconciliation_source_schema_fields",
+            joinColumns = @JoinColumn(name = "source_id", nullable = false))
+    @OrderColumn(name = "position")
+    private List<SourceSchemaField> schemaFields = new ArrayList<>();
 
     @Column(name = "created_at", nullable = false)
     private Instant createdAt = Instant.now();

--- a/backend/src/main/java/com/universal/reconciliation/domain/entity/SourceSchemaField.java
+++ b/backend/src/main/java/com/universal/reconciliation/domain/entity/SourceSchemaField.java
@@ -1,0 +1,36 @@
+package com.universal.reconciliation.domain.entity;
+
+import com.universal.reconciliation.domain.enums.FieldDataType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Embedded value representing a declared column inside a source schema.
+ */
+@Embeddable
+@Getter
+@Setter
+@EqualsAndHashCode
+public class SourceSchemaField {
+
+    @Column(name = "field_name", nullable = false, length = 128)
+    private String name;
+
+    @Column(name = "display_name", length = 256)
+    private String displayName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "data_type", length = 32)
+    private FieldDataType dataType;
+
+    @Column(name = "required", nullable = false)
+    private boolean required;
+
+    @Column(name = "description", length = 512)
+    private String description;
+}

--- a/backend/src/main/java/com/universal/reconciliation/service/admin/AdminReconciliationValidator.java
+++ b/backend/src/main/java/com/universal/reconciliation/service/admin/AdminReconciliationValidator.java
@@ -61,12 +61,31 @@ public class AdminReconciliationValidator {
                         "Arrival SLA minutes cannot be negative for source " + source.code());
             }
             transformationPlanProcessor.validate(source.transformationPlan());
+            validateSchemaFields(source);
         }
         if (anchorCount == 0) {
             throw new IllegalArgumentException("At least one source must be flagged as the anchor source.");
         }
         if (anchorCount > 1) {
             throw new IllegalArgumentException("Only a single anchor source can be configured per reconciliation.");
+        }
+    }
+
+    private void validateSchemaFields(AdminSourceRequest source) {
+        if (source.schemaFields() == null) {
+            return;
+        }
+        Set<String> fieldNames = new HashSet<>();
+        for (var field : source.schemaFields()) {
+            if (field == null || !StringUtils.hasText(field.name())) {
+                throw new IllegalArgumentException(
+                        "Schema field name is required for source " + source.code());
+            }
+            String key = normaliseKey(field.name());
+            if (!fieldNames.add(key)) {
+                throw new IllegalArgumentException(
+                        "Duplicate schema field name \"" + field.name() + "\" for source " + source.code());
+            }
         }
     }
 

--- a/backend/src/main/java/com/universal/reconciliation/service/admin/AdminSourceSchemaService.java
+++ b/backend/src/main/java/com/universal/reconciliation/service/admin/AdminSourceSchemaService.java
@@ -1,0 +1,213 @@
+package com.universal.reconciliation.service.admin;
+
+import com.universal.reconciliation.domain.dto.admin.AdminSourceSchemaFieldDto;
+import com.universal.reconciliation.domain.dto.admin.SourceSchemaInferenceRequest;
+import com.universal.reconciliation.domain.dto.admin.SourceSchemaInferenceResponse;
+import com.universal.reconciliation.domain.dto.admin.SourceTransformationPreviewUploadRequest;
+import com.universal.reconciliation.domain.enums.FieldDataType;
+import com.universal.reconciliation.service.transform.TransformationEvaluationException;
+import com.universal.reconciliation.service.transform.TransformationSampleFileService;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * Provides schema inference helpers for administrators defining source metadata.
+ */
+@Service
+public class AdminSourceSchemaService {
+
+    private static final List<DateTimeFormatter> DATE_FORMATTERS = List.of(
+            DateTimeFormatter.ISO_LOCAL_DATE,
+            DateTimeFormatter.ofPattern("yyyy/MM/dd"),
+            DateTimeFormatter.ofPattern("MM/dd/yyyy"),
+            DateTimeFormatter.ofPattern("dd/MM/yyyy"),
+            DateTimeFormatter.ofPattern("dd-MMM-yyyy", Locale.ENGLISH));
+
+    private final TransformationSampleFileService sampleFileService;
+
+    public AdminSourceSchemaService(TransformationSampleFileService sampleFileService) {
+        this.sampleFileService = sampleFileService;
+    }
+
+    public SourceSchemaInferenceResponse inferSchema(SourceSchemaInferenceRequest request, MultipartFile file) {
+        Objects.requireNonNull(request, "Inference request is required");
+        Objects.requireNonNull(file, "Sample file is required");
+
+        SourceTransformationPreviewUploadRequest previewRequest =
+                toPreviewRequest(request);
+        List<Map<String, Object>> rows = sampleFileService.parseSamples(previewRequest, file);
+
+        if (rows.isEmpty()) {
+            throw new TransformationEvaluationException("Sample did not contain any rows to infer schema");
+        }
+
+        List<AdminSourceSchemaFieldDto> fields = inferFields(rows);
+        return new SourceSchemaInferenceResponse(fields, rows);
+    }
+
+    private SourceTransformationPreviewUploadRequest toPreviewRequest(SourceSchemaInferenceRequest request) {
+        return new SourceTransformationPreviewUploadRequest(
+                request.fileType(),
+                request.hasHeader(),
+                request.delimiter(),
+                request.sheetName(),
+                Optional.ofNullable(request.sheetNames()).orElse(List.of()),
+                request.includeAllSheets(),
+                false,
+                null,
+                request.recordPath(),
+                request.encoding(),
+                request.limit(),
+                request.skipRows(),
+                null);
+    }
+
+    private List<AdminSourceSchemaFieldDto> inferFields(List<Map<String, Object>> rows) {
+        LinkedHashSet<String> columnOrder = new LinkedHashSet<>();
+        for (Map<String, Object> row : rows) {
+            for (String key : row.keySet()) {
+                if (StringUtils.hasText(key)) {
+                    columnOrder.add(key.trim());
+                }
+            }
+        }
+
+        List<AdminSourceSchemaFieldDto> fields = new ArrayList<>();
+        for (String column : columnOrder) {
+            ColumnSummary summary = summariseColumn(column, rows);
+            fields.add(new AdminSourceSchemaFieldDto(
+                    column,
+                    humanise(column),
+                    summary.dataType,
+                    summary.required,
+                    summary.description));
+        }
+        return fields;
+    }
+
+    private ColumnSummary summariseColumn(String column, List<Map<String, Object>> rows) {
+        ColumnSummary summary = new ColumnSummary();
+        summary.dataType = FieldDataType.STRING;
+        summary.required = true;
+
+        for (Map<String, Object> row : rows) {
+            if (!row.containsKey(column)) {
+                summary.required = false;
+                continue;
+            }
+            Object rawValue = row.get(column);
+            if (rawValue == null) {
+                summary.required = false;
+                continue;
+            }
+            String value = rawValue.toString().trim();
+            if (value.isEmpty()) {
+                summary.required = false;
+                continue;
+            }
+
+            summary.sampleValues.add(value);
+            summary.dataType = promoteType(summary.dataType, value);
+        }
+
+        if (summary.sampleValues.isEmpty()) {
+            summary.required = false;
+            summary.description = null;
+        } else {
+            summary.description = summary.sampleValues.stream().limit(3).collect(java.util.stream.Collectors.joining(", "));
+        }
+        return summary;
+    }
+
+    private FieldDataType promoteType(FieldDataType current, String value) {
+        if (looksLikeInteger(value)) {
+            if (current == FieldDataType.STRING) {
+                return FieldDataType.INTEGER;
+            }
+            if (current == FieldDataType.INTEGER) {
+                return FieldDataType.INTEGER;
+            }
+            if (current == FieldDataType.DECIMAL) {
+                return FieldDataType.DECIMAL;
+            }
+        }
+        if (looksLikeDecimal(value)) {
+            if (current == FieldDataType.STRING || current == FieldDataType.INTEGER) {
+                return FieldDataType.DECIMAL;
+            }
+            return current;
+        }
+        if (looksLikeDate(value)) {
+            if (current == FieldDataType.STRING) {
+                return FieldDataType.DATE;
+            }
+            return current;
+        }
+        return FieldDataType.STRING;
+    }
+
+    private boolean looksLikeInteger(String value) {
+        try {
+            new BigDecimal(value);
+            return value.matches("[-+]?\\d+");
+        } catch (NumberFormatException ex) {
+            return false;
+        }
+    }
+
+    private boolean looksLikeDecimal(String value) {
+        try {
+            new BigDecimal(value);
+            return value.contains(".");
+        } catch (NumberFormatException ex) {
+            return false;
+        }
+    }
+
+    private boolean looksLikeDate(String value) {
+        for (DateTimeFormatter formatter : DATE_FORMATTERS) {
+            try {
+                LocalDate.parse(value, formatter);
+                return true;
+            } catch (DateTimeParseException ignored) {
+                // continue
+            }
+        }
+        return false;
+    }
+
+    private String humanise(String column) {
+        if (!StringUtils.hasText(column)) {
+            return column;
+        }
+        String replaced = column
+                .replaceAll("[_-]+", " ")
+                .replaceAll("([a-z])([A-Z])", "$1 $2")
+                .trim();
+        if (replaced.isEmpty()) {
+            return column;
+        }
+        return Character.toUpperCase(replaced.charAt(0)) + replaced.substring(1);
+    }
+
+    private static class ColumnSummary {
+        FieldDataType dataType;
+        boolean required;
+        String description;
+        Set<String> sampleValues = new LinkedHashSet<>();
+    }
+}

--- a/backend/src/test/java/com/universal/reconciliation/service/admin/AdminReconciliationServiceIntegrationTest.java
+++ b/backend/src/test/java/com/universal/reconciliation/service/admin/AdminReconciliationServiceIntegrationTest.java
@@ -14,6 +14,7 @@ import com.universal.reconciliation.domain.dto.admin.AdminReconciliationSchemaDt
 import com.universal.reconciliation.domain.dto.admin.AdminReportColumnRequest;
 import com.universal.reconciliation.domain.dto.admin.AdminReportTemplateRequest;
 import com.universal.reconciliation.domain.dto.admin.AdminSourceRequest;
+import com.universal.reconciliation.domain.dto.admin.AdminSourceSchemaFieldRequest;
 import com.universal.reconciliation.domain.enums.AccessRole;
 import com.universal.reconciliation.domain.enums.ComparisonLogic;
 import com.universal.reconciliation.domain.enums.DataBatchStatus;
@@ -161,7 +162,10 @@ class AdminReconciliationServiceIntegrationTest {
                 "America/New_York",
                 60,
                 "{\"delimiter\":\",\"}",
-                null);
+                null,
+                List.of(
+                        new AdminSourceSchemaFieldRequest("trade_id", "Trade ID", FieldDataType.STRING, true, null),
+                        new AdminSourceSchemaFieldRequest("net_amount", "Net Amount", FieldDataType.DECIMAL, true, null)));
         AdminSourceRequest ledgerSource = new AdminSourceRequest(
                 null,
                 "GL_LEDGER",
@@ -174,7 +178,10 @@ class AdminReconciliationServiceIntegrationTest {
                 null,
                 null,
                 null,
-                null);
+                null,
+                List.of(
+                        new AdminSourceSchemaFieldRequest("trade_id", "Trade ID", FieldDataType.STRING, true, null),
+                        new AdminSourceSchemaFieldRequest("net_amount", "Net Amount", FieldDataType.DECIMAL, true, null)));
 
         AdminCanonicalFieldRequest tradeId = new AdminCanonicalFieldRequest(
                 null,

--- a/backend/src/test/java/com/universal/reconciliation/service/admin/AdminReconciliationValidatorTest.java
+++ b/backend/src/test/java/com/universal/reconciliation/service/admin/AdminReconciliationValidatorTest.java
@@ -44,7 +44,8 @@ class AdminReconciliationValidatorTest {
                                 null,
                                 null,
                                 null,
-                                null),
+                                null,
+                                List.of()),
                         new AdminSourceRequest(
                                 null,
                                 "GL",
@@ -57,7 +58,8 @@ class AdminReconciliationValidatorTest {
                                 null,
                                 null,
                                 null,
-                                null)),
+                                null,
+                                List.of())),
                 List.of(buildKeyField()));
 
         assertThatNoException().isThrownBy(() -> validator.validate(request));
@@ -79,7 +81,8 @@ class AdminReconciliationValidatorTest {
                                 null,
                                 null,
                                 null,
-                                null),
+                                null,
+                                List.of()),
                         new AdminSourceRequest(
                                 null,
                                 "GL",
@@ -92,7 +95,8 @@ class AdminReconciliationValidatorTest {
                                 null,
                                 null,
                                 null,
-                                null)),
+                                null,
+                                List.of())),
                 List.of(buildKeyField()));
 
         assertThatThrownBy(() -> validator.validate(request))
@@ -140,7 +144,8 @@ class AdminReconciliationValidatorTest {
                                 null,
                                 null,
                                 null,
-                                null)),
+                                null,
+                                List.of())),
                 List.of(compareField));
 
         assertThatThrownBy(() -> validator.validate(request))
@@ -188,7 +193,8 @@ class AdminReconciliationValidatorTest {
                                 null,
                                 null,
                                 null,
-                                null)),
+                                null,
+                                List.of())),
                 List.of(keyField));
 
         assertThatThrownBy(() -> validator.validate(request))
@@ -236,7 +242,8 @@ class AdminReconciliationValidatorTest {
                                 null,
                                 null,
                                 null,
-                                null)),
+                                null,
+                                List.of())),
                 List.of(compareField, buildKeyField()));
 
         assertThatThrownBy(() -> validator.validate(request))
@@ -258,7 +265,8 @@ class AdminReconciliationValidatorTest {
                 null,
                 -5,
                 null,
-                null);
+                null,
+                List.of());
 
         AdminReconciliationRequest request = buildRequest(List.of(source), List.of(buildKeyField()));
 
@@ -294,7 +302,8 @@ class AdminReconciliationValidatorTest {
                         null,
                         null,
                         null,
-                        null)),
+                        null,
+                        List.of())),
                 List.of(buildKeyField()),
                 List.of(),
                 List.of(new AdminAccessControlEntryRequest(
@@ -340,7 +349,8 @@ class AdminReconciliationValidatorTest {
                         null,
                         null,
                         null,
-                        null)),
+                        null,
+                        List.of())),
                 List.of(buildKeyField()),
                 List.of(),
                 List.of(new AdminAccessControlEntryRequest(

--- a/backend/src/test/java/com/universal/reconciliation/service/admin/AdminSourceSchemaServiceTest.java
+++ b/backend/src/test/java/com/universal/reconciliation/service/admin/AdminSourceSchemaServiceTest.java
@@ -1,0 +1,77 @@
+package com.universal.reconciliation.service.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.universal.reconciliation.domain.dto.admin.SourceSchemaInferenceRequest;
+import com.universal.reconciliation.domain.dto.admin.SourceSchemaInferenceResponse;
+import com.universal.reconciliation.domain.enums.FieldDataType;
+import com.universal.reconciliation.domain.enums.TransformationSampleFileType;
+import com.universal.reconciliation.service.transform.TransformationSampleFileService;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.web.multipart.MultipartFile;
+
+class AdminSourceSchemaServiceTest {
+
+    @Mock
+    private TransformationSampleFileService sampleFileService;
+
+    @Mock
+    private MultipartFile sample;
+
+    private AdminSourceSchemaService service;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        service = new AdminSourceSchemaService(sampleFileService);
+    }
+
+    @Test
+    void inferSchema_derivesColumnsAndTypes() {
+        when(sampleFileService.parseSamples(any(), eq(sample))).thenReturn(List.of(
+                Map.of("trade_id", "12345", "amount", "10.50", "tradeDate", "2024-05-01"),
+                Map.of("trade_id", "54321", "amount", "11.00", "tradeDate", "2024-05-02")));
+
+        SourceSchemaInferenceRequest request = new SourceSchemaInferenceRequest(
+                TransformationSampleFileType.CSV,
+                true,
+                ",",
+                null,
+                List.of(),
+                false,
+                null,
+                null,
+                10,
+                0);
+
+        SourceSchemaInferenceResponse response = service.inferSchema(request, sample);
+
+        assertThat(response.fields()).hasSize(3);
+        assertThat(response.fields())
+                .anySatisfy(field -> {
+                    if ("trade_id".equals(field.name())) {
+                        assertThat(field.dataType()).isEqualTo(FieldDataType.INTEGER);
+                        assertThat(field.required()).isTrue();
+                    }
+                })
+                .anySatisfy(field -> {
+                    if ("amount".equals(field.name())) {
+                        assertThat(field.dataType()).isEqualTo(FieldDataType.DECIMAL);
+                    }
+                })
+                .anySatisfy(field -> {
+                    if ("tradeDate".equals(field.name())) {
+                        assertThat(field.dataType()).isEqualTo(FieldDataType.DATE);
+                    }
+                });
+        assertThat(response.sampleRows()).hasSize(2);
+    }
+}

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -1,0 +1,17 @@
+# Admin Configurator Components
+
+## Wizard Flow
+
+- **Source Schema step** sits between Sources and Transformations. Administrators can upload a sample file or add
+  fields manually to define the raw schema for each source.
+- **Transformations** reuse the declared schema to surface column dropdowns and preview data consistently across the
+  wizard.
+- **Matching rules** draw from the schema-driven column catalogue, eliminating the need to maintain duplicate mappings
+  in multiple steps.
+
+## Backend Services
+
+- `AdminSourceSchemaService` reuses the transformation sample parser to infer field names, data types, and sample rows
+  from uploaded files.
+- `AdminReconciliationService` now persists `schemaFields` on each source. The stored schema is surfaced in
+  `AdminSourceDto` and exported through the reconciliation schema endpoint for downstream consumers.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,10 @@
+- **ADR: Source schema as first-class metadata (2025-10-03)**
+  - Problem: The legacy schema step duplicated matching controls, stored transformation snippets inline, and did not
+    persist a reusable view of raw source columns. Dropdowns in subsequent steps routinely drifted from the actual
+    source payload.
+  - Decision: Introduce a dedicated Source Schema step that persists `schemaFields` with name, display label, data
+    type, and required flag per source. The step supports manual editing and automated inference from sample files
+    using the existing transformation preview pipeline.
+  - Consequences: Matching and transformation steps consume a single source-of-truth column catalogue, making
+    dropdowns deterministic and keeping metadata changes auditable. Field-level transformation editing moved fully
+    into the transformations step.

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -1,0 +1,4 @@
+- **Source schema refactor (2025-10-03)**
+  - Reordered the admin configurator wizard so raw source schema capture precedes transformations and matching.
+  - Persisted per-source schema metadata and introduced automated inference from sample files.
+  - Simplified canonical schema maintenance by removing redundant transformation controls from the legacy schema step.

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -1,0 +1,16 @@
+# Patterns
+
+## Source Schema Capture
+- **Persist inferred metadata**: Always write schema inference results to `ReconciliationSource.schemaFields` so UI and
+  backend share a consistent view of available columns.
+- **Centralize parsing**: Reuse `AdminSourceSchemaService` to parse sample files instead of rolling ad-hoc parsers in
+  component code. The service honours the same options (`fileType`, `delimiter`, `sheetNames`, `recordPath`) as the
+  transformation preview pipeline.
+- **Derive display labels**: When no display name is provided, generate one by humanising the raw column (snake case /
+  camel case -> title case). Apply the same helper across backend and frontend to avoid drift.
+
+## Wizard Cohesion
+- **Single source of truth for columns**: Downstream steps (Transformations, Matching, Reports) should rely on
+  `availableColumns` derived from schema fields and transformation outputs rather than maintaining duplicate lists.
+- **Dirty state propagation**: Updating schema fields must mark the underlying `FormArray` as dirty/touched so the
+  review step surfaces unsaved changes and guards navigation.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,15 @@
+# Troubleshooting
+
+## Schema inference fails for uploaded files
+- **Symptom**: Admin wizard displays "Unable to infer schema from the uploaded file".
+- **Checklist**:
+  - Confirm the selected file size is below `admin.transformations.preview.max-upload-bytes` (default 2 MiB).
+  - Ensure the chosen file type matches the payload (CSV vs Excel vs JSON/XML) and that delimiter/header options align.
+  - For Excel workbooks, refresh sheet metadata after uploading to populate the sheet selector.
+- **Diagnostics**: Backend logs include `TransformationEvaluationException` entries with the root cause. Re-run with
+  `DEBUG` logging on `AdminSourceSchemaService` for additional context.
+
+## Schema fields missing in matching dropdowns
+- Verify the schema step fields were saved (wizard review page lists schema counts per source).
+- Check that transformations preview succeeded; available columns combine schema fields with derived columns.
+- When editing existing reconciliations, the Sources tab must be saved before schema changes propagate to matching.

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -47,6 +47,7 @@ graph LR
 - **Reporting engine:** Builds Excel outputs from database templates and exposes download endpoints via `/api/exports`.
 - **Activity service:** Streams structured events for observability, compliance, and analytics.
 - **Integration connectors:** Metadata-driven ETL pipelines, scheduler/RPA triggers, and Kafka topics orchestrate data ingest and downstream automation.
+- **Admin configurator:** Multi-step Angular wizard backed by REST endpoints. The new Source Schema step persists per-source column metadata which fuels transformation previews and matching dropdowns. Schema inference uses the transformation sample parser to detect column names, data types, and sample rows from uploaded files.
 - **Observability stack:** Activity telemetry and platform metrics flow into enterprise APM/SIEM tooling for health monitoring.
 
 ### 2.3 Design Patterns Used
@@ -165,6 +166,7 @@ erDiagram
 - `ExportService` – Generates Excel exports leveraging Apache POI and the configured report templates.
 - `SystemActivityService` – Persists audit events (`SystemEventType`) and exposes them to the `/api/activity` endpoint.
 - `UserContext` – Lightweight wrapper around Spring Security providing current username and group memberships for downstream services.
+- `AdminSourceSchemaService` – Reuses the transformation preview pipeline to infer per-source schema metadata (field name, data type, required flag, sample rows) from administrator-provided files. `AdminReconciliationService` stores the resulting schema fields alongside each `ReconciliationSource` and exposes them to the UI and schema export endpoints.
 
 ### 5.3 Application Properties
 | Property | Purpose | Example |

--- a/examples/admin-configurator/payloads/reconciliation.json
+++ b/examples/admin-configurator/payloads/reconciliation.json
@@ -23,7 +23,12 @@
       "arrivalExpectation": "Weekdays by 18:00",
       "arrivalTimezone": "America/New_York",
       "arrivalSlaMinutes": 60,
-      "adapterOptions": "{\"delimiter\":\",\"}"
+      "adapterOptions": "{\"delimiter\":\",\"}",
+      "schemaFields": [
+        { "name": "trade_id", "displayName": "Trade ID", "dataType": "STRING", "required": true },
+        { "name": "net_amount", "displayName": "Net Amount", "dataType": "DECIMAL", "required": true },
+        { "name": "currency", "displayName": "Currency", "dataType": "STRING", "required": true }
+      ]
     },
     {
       "id": null,
@@ -36,7 +41,12 @@
       "arrivalExpectation": null,
       "arrivalTimezone": null,
       "arrivalSlaMinutes": null,
-      "adapterOptions": null
+      "adapterOptions": null,
+      "schemaFields": [
+        { "name": "trade_id", "displayName": "Trade ID", "dataType": "STRING", "required": true },
+        { "name": "net_amount", "displayName": "Net Amount", "dataType": "DECIMAL", "required": true },
+        { "name": "currency", "displayName": "Currency", "dataType": "STRING", "required": true }
+      ]
     }
   ],
   "canonicalFields": [

--- a/examples/integration-harness/payloads/cash-vs-gl.json
+++ b/examples/integration-harness/payloads/cash-vs-gl.json
@@ -24,6 +24,13 @@
       "arrivalTimezone": "America/New_York",
       "arrivalSlaMinutes": 30,
       "adapterOptions": "{\"delimiter\":\",\"}",
+      "schemaFields": [
+        { "name": "transactionId", "displayName": "Transaction ID", "dataType": "STRING", "required": true },
+        { "name": "valueDate", "displayName": "Value Date", "dataType": "DATE", "required": true },
+        { "name": "currency", "displayName": "Currency", "dataType": "STRING", "required": true },
+        { "name": "amount", "displayName": "Amount", "dataType": "DECIMAL", "required": true },
+        { "name": "notes", "displayName": "Notes", "dataType": "STRING", "required": false }
+      ],
       "transformationPlan": {
         "datasetGroovyScript": "rows.each { current ->\n  def currency = current.currency\n  if (currency != null) {\n    current.currency = currency.toString().trim()\n  }\n}",
         "rowOperations": [
@@ -70,6 +77,14 @@
       "arrivalTimezone": "America/New_York",
       "arrivalSlaMinutes": 45,
       "adapterOptions": "{\"delimiter\":\",\"}",
+      "schemaFields": [
+        { "name": "transactionId", "displayName": "Transaction ID", "dataType": "STRING", "required": true },
+        { "name": "valueDate", "displayName": "Value Date", "dataType": "DATE", "required": true },
+        { "name": "currency", "displayName": "Currency", "dataType": "STRING", "required": true },
+        { "name": "amount", "displayName": "Amount", "dataType": "DECIMAL", "required": true },
+        { "name": "product", "displayName": "Product", "dataType": "STRING", "required": false },
+        { "name": "status", "displayName": "Status", "dataType": "STRING", "required": false }
+      ],
       "transformationPlan": {
         "datasetGroovyScript": "rows.each { current ->\n  if (current.notes == null) {\n    current.notes = ''\n  }\n}",
         "rowOperations": [

--- a/examples/integration-harness/payloads/custodian-trade.json
+++ b/examples/integration-harness/payloads/custodian-trade.json
@@ -23,7 +23,16 @@
       "arrivalExpectation": "Morning 09:15 & Evening 18:00 Eastern",
       "arrivalTimezone": "America/New_York",
       "arrivalSlaMinutes": 30,
-      "adapterOptions": "{\"delimiter\":\",\",\"header\":true}"
+      "adapterOptions": "{\"delimiter\":\",\",\"header\":true}",
+      "schemaFields": [
+        { "name": "trade_id", "displayName": "Trade ID", "dataType": "STRING", "required": true },
+        { "name": "source", "displayName": "Source", "dataType": "STRING", "required": true },
+        { "name": "gross_amount", "displayName": "Gross Amount", "dataType": "DECIMAL", "required": true },
+        { "name": "quantity", "displayName": "Quantity", "dataType": "DECIMAL", "required": true },
+        { "name": "currency", "displayName": "Currency", "dataType": "STRING", "required": true },
+        { "name": "trade_date", "displayName": "Trade Date", "dataType": "DATE", "required": true },
+        { "name": "book", "displayName": "Book", "dataType": "STRING", "required": false }
+      ]
     },
     {
       "id": null,
@@ -36,7 +45,16 @@
       "arrivalExpectation": "Morning 08:30 & Evening 17:30 Eastern",
       "arrivalTimezone": "America/New_York",
       "arrivalSlaMinutes": 45,
-      "adapterOptions": "{\"delimiter\":\",\",\"header\":true}"
+      "adapterOptions": "{\"delimiter\":\",\"header\":true}",
+      "schemaFields": [
+        { "name": "trade_id", "displayName": "Trade ID", "dataType": "STRING", "required": true },
+        { "name": "source", "displayName": "Source", "dataType": "STRING", "required": true },
+        { "name": "gross_amount", "displayName": "Gross Amount", "dataType": "DECIMAL", "required": true },
+        { "name": "quantity", "displayName": "Quantity", "dataType": "DECIMAL", "required": true },
+        { "name": "currency", "displayName": "Currency", "dataType": "STRING", "required": true },
+        { "name": "trade_date", "displayName": "Trade Date", "dataType": "DATE", "required": true },
+        { "name": "desk", "displayName": "Desk", "dataType": "STRING", "required": false }
+      ]
     }
   ],
   "canonicalFields": [

--- a/examples/integration-harness/payloads/securities-position.json
+++ b/examples/integration-harness/payloads/securities-position.json
@@ -23,7 +23,16 @@
       "arrivalExpectation": "Global cut by 17:30 London",
       "arrivalTimezone": "Europe/London",
       "arrivalSlaMinutes": 45,
-      "adapterOptions": "{\"delimiter\":\",\"}"
+      "adapterOptions": "{\"delimiter\":\",\"}",
+      "schemaFields": [
+        { "name": "transactionId", "displayName": "Position ID", "dataType": "STRING", "required": true },
+        { "name": "accountId", "displayName": "Account", "dataType": "STRING", "required": true },
+        { "name": "isin", "displayName": "ISIN", "dataType": "STRING", "required": true },
+        { "name": "quantity", "displayName": "Quantity", "dataType": "DECIMAL", "required": true },
+        { "name": "marketValue", "displayName": "Market Value", "dataType": "DECIMAL", "required": true },
+        { "name": "valuationCurrency", "displayName": "Valuation CCY", "dataType": "STRING", "required": true },
+        { "name": "valuationDate", "displayName": "Valuation Date", "dataType": "DATE", "required": true }
+      ]
     },
     {
       "id": null,
@@ -36,7 +45,16 @@
       "arrivalExpectation": "Downstream publish by 17:15 London",
       "arrivalTimezone": "Europe/London",
       "arrivalSlaMinutes": 30,
-      "adapterOptions": "{\"delimiter\":\",\"}"
+      "adapterOptions": "{\"delimiter\":\",\"}",
+      "schemaFields": [
+        { "name": "transactionId", "displayName": "Position ID", "dataType": "STRING", "required": true },
+        { "name": "accountId", "displayName": "Account", "dataType": "STRING", "required": true },
+        { "name": "isin", "displayName": "ISIN", "dataType": "STRING", "required": true },
+        { "name": "quantity", "displayName": "Quantity", "dataType": "DECIMAL", "required": true },
+        { "name": "marketValue", "displayName": "Market Value", "dataType": "DECIMAL", "required": true },
+        { "name": "valuationCurrency", "displayName": "Valuation CCY", "dataType": "STRING", "required": true },
+        { "name": "valuationDate", "displayName": "Valuation Date", "dataType": "DATE", "required": true }
+      ]
     }
   ],
   "canonicalFields": [

--- a/frontend/src/app/components/admin/admin-reconciliation-detail.component.css
+++ b/frontend/src/app/components/admin/admin-reconciliation-detail.component.css
@@ -84,6 +84,26 @@
   background: #f8fafc;
 }
 
+.source-schema {
+  margin-top: 1rem;
+}
+
+.source-schema h5 {
+  margin: 0 0 0.5rem;
+}
+
+.source-schema table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.source-schema th,
+.source-schema td {
+  text-align: left;
+  padding: 0.5rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
 .source-card header {
   display: flex;
   justify-content: space-between;

--- a/frontend/src/app/components/admin/admin-reconciliation-detail.component.html
+++ b/frontend/src/app/components/admin/admin-reconciliation-detail.component.html
@@ -89,6 +89,30 @@
         </li>
         <li *ngIf="source.adapterOptions"><strong>Adapter options:</strong> {{ source.adapterOptions }}</li>
       </ul>
+      <div *ngIf="source.schemaFields?.length" class="source-schema">
+        <h5>Source schema ({{ source.schemaFields.length }} fields)</h5>
+        <table>
+          <thead>
+            <tr>
+              <th>Column</th>
+              <th>Data type</th>
+              <th>Required</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let field of source.schemaFields">
+              <td>
+                {{ field.displayName || field.name }}
+                <span class="muted" *ngIf="field.displayName">({{ field.name }})</span>
+              </td>
+              <td>{{ field.dataType }}</td>
+              <td>{{ field.required ? 'Yes' : 'No' }}</td>
+              <td>{{ field.description || '-' }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
       <form class="ingestion-form" (submit)="submitBatch(detail, source); $event.preventDefault()">
         <label>
           Batch label

--- a/frontend/src/app/components/admin/admin-reconciliation-wizard.component.css
+++ b/frontend/src/app/components/admin/admin-reconciliation-wizard.component.css
@@ -102,7 +102,7 @@
 }
 
 .sources-step .source-form,
-.schema-step .field-card,
+.schema-step .schema-card,
 .reports-step .report-form,
 .access-step .access-form {
   border: 1px solid #e2e8f0;
@@ -181,6 +181,77 @@
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 0.75rem;
   align-items: end;
+}
+
+.schema-summary {
+  display: grid;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.schema-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.schema-upload-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+  align-items: end;
+}
+
+.schema-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.schema-fields {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.schema-fields-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.schema-fields-table {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.schema-field-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+  align-items: end;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 0.75rem;
+  background: #fff;
+}
+
+.schema-sample {
+  display: grid;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.schema-sample pre {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 0.6rem;
+  border-radius: 6px;
+  overflow-x: auto;
+}
+
+.file-input input[type='file'] {
+  padding: 0.4rem 0;
 }
 
 .llm-options {

--- a/frontend/src/app/components/admin/admin-reconciliation-wizard.component.css
+++ b/frontend/src/app/components/admin/admin-reconciliation-wizard.component.css
@@ -611,6 +611,57 @@
   font-size: 10px;
   margin-left: 0.4rem;
   cursor: help;
+  position: relative;
+  color: #0f172a;
+  background: #f8fafc;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.info-icon:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
+.info-icon .info-tooltip {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 10px);
+  transform: translate(-50%, 6px);
+  background: #0f172a;
+  color: #f8fafc;
+  padding: 0.35rem 0.55rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.2;
+  white-space: normal;
+  width: max-content;
+  max-width: 260px;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.2);
+  opacity: 0;
+  pointer-events: none;
+  z-index: 30;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+  text-align: left;
+}
+
+.info-icon .info-tooltip::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 100%;
+  transform: translate(-50%, -6px);
+  border-width: 6px;
+  border-style: solid;
+  border-color: #0f172a transparent transparent transparent;
+}
+
+.info-icon:hover .info-tooltip,
+.info-icon:focus .info-tooltip,
+.info-icon:focus-visible .info-tooltip {
+  opacity: 1;
+  transform: translate(-50%, 0);
 }
 
 .field-label {

--- a/frontend/src/app/components/admin/admin-reconciliation-wizard.component.html
+++ b/frontend/src/app/components/admin/admin-reconciliation-wizard.component.html
@@ -118,6 +118,225 @@
       <button type="button" class="secondary" (click)="addSource()">Add source</button>
     </section>
 
+    <section *ngSwitchCase="'schema'" formArrayName="sources" class="schema-step">
+      <header class="schema-summary">
+        <h3>Define source schemas</h3>
+        <p>
+          Upload representative files to auto-populate columns for each source, then refine field names, data types,
+          and requirements. These columns power transformation previews and matching rules.
+        </p>
+      </header>
+
+      <article
+        *ngFor="let sourceGroup of sources.controls; let i = index"
+        [formGroupName]="i"
+        class="schema-card"
+      >
+        <header class="schema-card-header">
+          <div>
+            <h4>{{ sourceGroup.get('displayName')?.value || ('Source ' + (i + 1)) }}</h4>
+            <p class="hint">Code: {{ sourceGroup.get('code')?.value || 'unset' }}</p>
+          </div>
+          <div class="schema-actions">
+            <button
+              type="button"
+              class="secondary"
+              (click)="inferSchemaFromFile(i)"
+              [disabled]="sourcePreviewState[i]?.schemaUploading"
+            >
+              {{ sourcePreviewState[i]?.schemaUploading ? 'Inferring…' : 'Infer schema from file' }}
+            </button>
+          </div>
+        </header>
+
+        <div class="schema-upload-grid">
+          <label>
+            File type
+            <span class="info-icon" title="Select the format of the uploaded sample file.">i</span>
+            <select
+              [value]="sourcePreviewState[i]?.fileType"
+              (change)="setSourcePreviewOption(i, 'fileType', $any($event.target).value)"
+            >
+              <option value="CSV">CSV</option>
+              <option value="DELIMITED">DELIMITED</option>
+              <option value="EXCEL">EXCEL</option>
+              <option value="JSON">JSON</option>
+              <option value="XML">XML</option>
+            </select>
+          </label>
+          <label *ngIf="['CSV','DELIMITED','EXCEL'].includes(sourcePreviewState[i]?.fileType ?? '')" class="checkbox">
+            <input
+              type="checkbox"
+              [checked]="sourcePreviewState[i]?.hasHeader"
+              (change)="setSourcePreviewOption(i, 'hasHeader', $any($event.target).checked)"
+            />
+            Has header row
+          </label>
+          <label *ngIf="['CSV','DELIMITED'].includes(sourcePreviewState[i]?.fileType ?? '')">
+            Delimiter
+            <span class="info-icon" title="Single character separating values in the file.">i</span>
+            <input
+              type="text"
+              maxlength="1"
+              [value]="sourcePreviewState[i]?.delimiter || ','"
+              (input)="setSourcePreviewOption(i, 'delimiter', $any($event.target).value)"
+            />
+          </label>
+          <label *ngIf="sourcePreviewState[i]?.fileType === 'EXCEL'">
+            Sheet name
+            <input
+              type="text"
+              [value]="sourcePreviewState[i]?.sheetName || ''"
+              (input)="setSourcePreviewOption(i, 'sheetName', $any($event.target).value)"
+            />
+          </label>
+          <label *ngIf="sourcePreviewState[i]?.fileType === 'EXCEL'">
+            Sheet selection
+            <select multiple (change)="onSheetSelectionChange(i, $event)">
+              <option
+                *ngFor="let name of sourcePreviewState[i]?.availableSheetNames ?? []"
+                [selected]="sourcePreviewState[i]?.sheetNames?.includes(name)"
+                [value]="name"
+              >
+                {{ name }}
+              </option>
+            </select>
+            <div class="inline-actions">
+              <label class="checkbox">
+                <input
+                  type="checkbox"
+                  [checked]="sourcePreviewState[i]?.includeAllSheets"
+                  (change)="setSourcePreviewOption(i, 'includeAllSheets', $any($event.target).checked)"
+                />
+                Include all sheets
+              </label>
+              <button
+                type="button"
+                class="link"
+                (click)="fetchSheetNames(i)"
+                [disabled]="sourcePreviewState[i]?.sheetNamesLoading"
+              >
+                {{ sourcePreviewState[i]?.sheetNamesLoading ? 'Refreshing…' : 'Refresh list' }}
+              </button>
+            </div>
+          </label>
+          <label *ngIf="sourcePreviewState[i]?.fileType === 'EXCEL' && sourcePreviewState[i]?.includeSheetNameColumn">
+            Sheet name column
+            <input
+              type="text"
+              placeholder="_sheet"
+              [value]="sourcePreviewState[i]?.sheetNameColumn || ''"
+              (input)="setSourcePreviewOption(i, 'sheetNameColumn', $any($event.target).value)"
+            />
+          </label>
+          <label *ngIf="['JSON','XML'].includes(sourcePreviewState[i]?.fileType ?? '')">
+            Record path
+            <span class="info-icon" title="Dot notation path to the array of records in the JSON or XML payload.">i</span>
+            <input
+              type="text"
+              placeholder="e.g. data.items"
+              [value]="sourcePreviewState[i]?.recordPath || ''"
+              (input)="setSourcePreviewOption(i, 'recordPath', $any($event.target).value)"
+            />
+          </label>
+          <label>
+            Encoding
+            <input
+              type="text"
+              placeholder="UTF-8"
+              [value]="sourcePreviewState[i]?.encoding || ''"
+              (input)="setSourcePreviewOption(i, 'encoding', $any($event.target).value)"
+            />
+          </label>
+          <label>
+            Max rows
+            <input
+              type="number"
+              min="1"
+              max="50"
+              [value]="sourcePreviewState[i]?.limit"
+              (input)="setSourcePreviewOption(i, 'limit', Number($any($event.target).value))"
+            />
+          </label>
+          <label *ngIf="['CSV','DELIMITED','EXCEL'].includes(sourcePreviewState[i]?.fileType ?? '')">
+            Skip rows
+            <input
+              type="number"
+              min="0"
+              max="500"
+              [value]="sourcePreviewState[i]?.skipRows || 0"
+              (input)="setSourcePreviewOption(i, 'skipRows', Number($any($event.target).value))"
+            />
+          </label>
+          <label class="file-input">
+            Sample file
+            <input type="file" (change)="onSourceSampleFileSelected(i, $event)" />
+          </label>
+        </div>
+
+        <p class="error" *ngIf="sourcePreviewState[i]?.schemaError">{{ sourcePreviewState[i]?.schemaError }}</p>
+
+        <div class="schema-sample" *ngIf="sourcePreviewState[i]?.schemaSampleRows?.length">
+          <h5>Preview rows</h5>
+          <pre *ngFor="let row of sourcePreviewState[i]?.schemaSampleRows | slice:0:5">{{ row | json }}</pre>
+        </div>
+
+        <section formArrayName="schemaFields" class="schema-fields">
+          <header class="schema-fields-header">
+            <h5>Fields</h5>
+            <p class="hint">
+              Edit detected fields or add new ones. These names populate dropdowns in transformations and matching.
+            </p>
+          </header>
+          <div class="schema-fields-table" *ngIf="schemaFieldsArray(i).length > 0; else noSchemaFields">
+            <div
+              class="schema-field-row"
+              *ngFor="let fieldGroup of schemaFieldsArray(i).controls; let f = index"
+              [formGroupName]="f"
+            >
+              <label>
+                Column name
+                <input
+                  type="text"
+                  formControlName="name"
+                  (input)="onSchemaFieldNameChange(i)"
+                  placeholder="e.g. trade_id"
+                />
+              </label>
+              <label>
+                Display name
+                <input
+                  type="text"
+                  formControlName="displayName"
+                  placeholder="Trade ID"
+                />
+              </label>
+              <label>
+                Data type
+                <select formControlName="dataType">
+                  <option *ngFor="let type of dataTypes" [value]="type">{{ type }}</option>
+                </select>
+              </label>
+              <label class="checkbox">
+                <input type="checkbox" formControlName="required" /> Required
+              </label>
+              <label>
+                Description
+                <input type="text" formControlName="description" placeholder="Optional context" />
+              </label>
+              <button type="button" class="link" (click)="removeSchemaField(i, f)" *ngIf="schemaFieldsArray(i).length > 1">
+                Remove
+              </button>
+            </div>
+          </div>
+          <ng-template #noSchemaFields>
+            <p class="hint">No fields defined yet. Add fields manually or infer them from a sample file.</p>
+          </ng-template>
+          <button type="button" class="secondary" (click)="addSchemaField(i)">Add field</button>
+        </section>
+      </article>
+    </section>
+
     <section *ngSwitchCase="'transformations'" formArrayName="sources" class="transformations-step">
       <p class="hint">
         Upload sample data or load recent rows to preview how source-level transformations change the dataset
@@ -805,7 +1024,7 @@
                   </datalist>
                 </label>
                 <p class="hint" *ngIf="columnsForMapping(i, m).length === 0">
-                  Upload transformation samples or map fields in the schema step to surface columns.
+                  Define fields in the source schema step or infer them from a sample file to surface column options.
                 </p>
               </div>
               <div class="mapping-date" *ngIf="isDateMatch(fieldGroup)">
@@ -833,213 +1052,6 @@
           </div>
         </article>
       </div>
-    </section>
-
-    <section *ngSwitchCase="'schema'" formArrayName="canonicalFields" class="schema-step">
-      <article *ngFor="let fieldGroup of canonicalFields.controls; let i = index" [formGroupName]="i" class="field-card">
-        <header>
-          <h3>Field {{ i + 1 }}</h3>
-          <button type="button" class="link" (click)="removeCanonicalField(i)" *ngIf="canonicalFields.length > 1">Remove</button>
-        </header>
-        <div class="grid">
-          <label>Canonical name<input type="text" formControlName="canonicalName" /></label>
-          <label>Display name<input type="text" formControlName="displayName" /></label>
-          <label>
-            Role
-            <select formControlName="role">
-              <option *ngFor="let role of fieldRoles" [value]="role">{{ role }}</option>
-            </select>
-          </label>
-          <label>
-            Data type
-            <select formControlName="dataType">
-              <option *ngFor="let type of dataTypes" [value]="type">{{ type }}</option>
-            </select>
-          </label>
-          <label>
-            Comparison
-            <select formControlName="comparisonLogic">
-              <option *ngFor="let logic of comparisonLogics" [value]="logic">{{ logic }}</option>
-            </select>
-          </label>
-          <label>Threshold %<input type="number" formControlName="thresholdPercentage" /></label>
-          <label>Display order<input type="number" formControlName="displayOrder" /></label>
-          <label>Formatting hint<input type="text" formControlName="formattingHint" placeholder="e.g. YYYY-MM-DD" /></label>
-          <label class="checkbox"><input type="checkbox" formControlName="required" /> Required</label>
-        </div>
-        <div formArrayName="mappings" class="mappings">
-          <h4>Mappings</h4>
-          <div *ngFor="let mappingGroup of sourceMappings(i).controls; let m = index" [formGroupName]="m" class="mapping-row">
-            <div class="mapping-grid">
-              <label>Source<input type="text" formControlName="sourceCode" (input)="invalidateMappingPreview(i, m)" /></label>
-              <label
-                >Column<input
-                  type="text"
-                  formControlName="sourceColumn"
-                  (input)="onSourceColumnChange(i, m, $any($event.target).value)"
-                />
-              </label>
-              <label>Legacy expression
-                <span class="info-icon" title="Optional expression executed for older ingestion flows before new transformation rules.">i</span>
-                <input type="text" formControlName="transformationExpression" placeholder="Optional legacy expression" />
-              </label>
-              <label>Default
-                <span class="info-icon" title="Value used when the source column is missing or blank.">i</span>
-                <input type="text" formControlName="defaultValue" />
-              </label>
-              <label>Ordinal
-                <span class="info-icon" title="Controls the relative ordering of mappings when multiple columns are processed.">i</span>
-                <input type="number" formControlName="ordinalPosition" />
-              </label>
-              <label class="checkbox"><input type="checkbox" formControlName="required" /> Required</label>
-              <button type="button" class="link" (click)="removeMapping(i, m)">Remove mapping</button>
-            </div>
-
-            <div formArrayName="transformations" class="transformation-list">
-              <h5>Transformations</h5>
-              <div
-                *ngFor="let transformationGroup of mappingTransformations(i, m).controls; let t = index"
-                [formGroupName]="t"
-                class="transformation-card"
-              >
-                <div class="transformation-header">
-                  <label>
-                    Type
-                    <select formControlName="type" (change)="onTransformationTypeChange(i, m, t)">
-                      <option *ngFor="let type of transformationTypes" [value]="type">{{ type }}</option>
-                    </select>
-                  </label>
-                  <label>
-                    Display order
-                    <input type="number" formControlName="displayOrder" />
-                  </label>
-                  <label class="checkbox"><input type="checkbox" formControlName="active" /> Active</label>
-                </div>
-
-                <div class="transformation-body">
-                  <ng-container [ngSwitch]="transformationGroup.get('type')?.value">
-                    <div *ngSwitchCase="'GROOVY_SCRIPT'" class="transformation-editor">
-                      <label
-                        >Groovy script<textarea
-                          formControlName="expression"
-                          rows="4"
-                          placeholder="return value"
-                          (input)="invalidateMappingPreview(i, m)"
-                        ></textarea
-                      ></label>
-                      <div class="groovy-tools">
-                        <ng-container *ngIf="getGroovyAssistantState(i, m, t) as assistantState">
-                          <div class="groovy-assistant">
-                            <label>
-                              Describe transformation<textarea
-                                rows="3"
-                                [value]="assistantState.prompt"
-                                placeholder="Explain how the source value should be transformed"
-                                (input)="onGroovyPromptChange(i, m, t, $event)"
-                              ></textarea>
-                            </label>
-                            <div class="groovy-assistant-actions">
-                              <button
-                                type="button"
-                                class="secondary"
-                                (click)="generateGroovyScript(i, m, t)"
-                                [disabled]="assistantState.generating"
-                              >
-                                {{ assistantState.generating ? 'Generating…' : 'Generate with AI' }}
-                              </button>
-                              <span class="hint" *ngIf="assistantState.generating">Requesting Groovy script…</span>
-                            </div>
-                            <p class="hint" *ngIf="assistantState.summary && !assistantState.generating">
-                              {{ assistantState.summary }}
-                            </p>
-                            <p class="error" *ngIf="assistantState.error">{{ assistantState.error }}</p>
-                          </div>
-                        </ng-container>
-                        <div class="groovy-actions">
-                          <button
-                            type="button"
-                            class="secondary"
-                            (click)="runGroovyTest(i, m, t)"
-                            [disabled]="getGroovyTestState(i, m, t).running"
-                          >
-                            Run Groovy test
-                          </button>
-                          <p class="hint">
-                            Load sample rows for this source in the Transformations step to execute the script with
-                            real data.
-                          </p>
-                        </div>
-                      </div>
-                    </div>
-                    <div *ngSwitchCase="'EXCEL_FORMULA'" class="transformation-editor">
-                      <label
-                        >Excel formula<input
-                          type="text"
-                          formControlName="expression"
-                          placeholder="=VALUE"
-                          (input)="invalidateMappingPreview(i, m)"
-                        />
-                      </label>
-                      <p class="hint">Use VALUE or column names (e.g. CASH_AMOUNT) as named references.</p>
-                    </div>
-                    <div *ngSwitchCase="'FUNCTION_PIPELINE'" class="transformation-editor" formArrayName="pipelineSteps">
-                      <div
-                        *ngFor="let stepGroup of pipelineSteps(i, m, t).controls; let s = index"
-                        [formGroupName]="s"
-                        class="pipeline-step"
-                      >
-                        <label>
-                          Function
-                          <select formControlName="function" (change)="invalidateMappingPreview(i, m)">
-                            <option *ngFor="let fn of pipelineFunctionOptions" [value]="fn.value">{{ fn.label }}</option>
-                          </select>
-                        </label>
-                        <div formArrayName="args" class="pipeline-args">
-                          <div
-                            *ngFor="let argCtrl of pipelineStepArgs(i, m, t, s).controls; let a = index"
-                            class="arg-row"
-                          >
-                            <label
-                              >Arg {{ a + 1 }}<input
-                                [formControlName]="a"
-                                placeholder="Value or {{column}}"
-                                (input)="invalidateMappingPreview(i, m)"
-                              />
-                            </label>
-                            <button type="button" class="link" (click)="removePipelineArg(i, m, t, s, a)">Remove</button>
-                          </div>
-                          <button type="button" class="secondary" (click)="addPipelineArg(i, m, t, s)">Add argument</button>
-                        </div>
-                        <button
-                          type="button"
-                          class="link"
-                          (click)="removePipelineStep(i, m, t, s)"
-                          *ngIf="pipelineSteps(i, m, t).length > 1"
-                        >
-                          Remove step
-                        </button>
-                      </div>
-                      <button type="button" class="secondary" (click)="addPipelineStep(i, m, t)">Add step</button>
-                    </div>
-                  </ng-container>
-                </div>
-
-                <div class="transformation-actions">
-                  <button type="button" class="secondary" (click)="validateTransformation(i, m, t)">Validate rule</button>
-                  <button type="button" class="link" (click)="removeTransformation(i, m, t)">Remove</button>
-                </div>
-                <p class="hint" *ngIf="transformationGroup.get('validationMessage')?.value">
-                  {{ transformationGroup.get('validationMessage')?.value }}
-                </p>
-              </div>
-              <button type="button" class="secondary" (click)="addTransformation(i, m)">Add transformation</button>
-            </div>
-
-          </div>
-          <button type="button" class="secondary" (click)="addMapping(i)">Add mapping</button>
-        </div>
-      </article>
-      <button type="button" class="secondary" (click)="addCanonicalField()">Add canonical field</button>
     </section>
 
     <section *ngSwitchCase="'reports'" formArrayName="reportTemplates" class="reports-step">

--- a/frontend/src/app/components/admin/admin-reconciliation-wizard.component.ts
+++ b/frontend/src/app/components/admin/admin-reconciliation-wizard.component.ts
@@ -52,6 +52,7 @@ import {
   TransformationValidationResponse
 } from '../../models/admin-api-models';
 import { AdminReconciliationStateService } from '../../services/admin-reconciliation-state.service';
+import { InfoIconTooltipDirective } from './info-icon-tooltip.directive';
 
 interface WizardStep {
   key: string;
@@ -131,7 +132,7 @@ type MatchRuleType = 'FULL' | 'CASE_INSENSITIVE' | 'THRESHOLD' | 'DATE' | 'DISPL
 @Component({
   selector: 'urp-admin-reconciliation-wizard',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, NgIf, NgFor, AsyncPipe],
+  imports: [CommonModule, ReactiveFormsModule, NgIf, NgFor, AsyncPipe, InfoIconTooltipDirective],
   templateUrl: './admin-reconciliation-wizard.component.html',
   styleUrls: ['./admin-reconciliation-wizard.component.css']
 })

--- a/frontend/src/app/components/admin/info-icon-tooltip.directive.ts
+++ b/frontend/src/app/components/admin/info-icon-tooltip.directive.ts
@@ -1,0 +1,40 @@
+import { AfterViewInit, Directive, ElementRef, Renderer2 } from '@angular/core';
+
+let tooltipIdSeed = 0;
+
+@Directive({
+  standalone: true,
+  selector: 'span.info-icon[title]'
+})
+export class InfoIconTooltipDirective implements AfterViewInit {
+  constructor(private readonly elementRef: ElementRef<HTMLElement>, private readonly renderer: Renderer2) {}
+
+  ngAfterViewInit(): void {
+    const host = this.elementRef.nativeElement;
+    const tooltip = host.getAttribute('title')?.trim();
+
+    if (!tooltip) {
+      host.removeAttribute('title');
+      return;
+    }
+
+    const tooltipId = `info-icon-tooltip-${++tooltipIdSeed}`;
+
+    const tooltipContainer = this.renderer.createElement('span');
+    this.renderer.addClass(tooltipContainer, 'info-tooltip');
+    this.renderer.setAttribute(tooltipContainer, 'role', 'tooltip');
+    this.renderer.setAttribute(tooltipContainer, 'id', tooltipId);
+    this.renderer.appendChild(tooltipContainer, this.renderer.createText(tooltip));
+
+    this.renderer.appendChild(host, tooltipContainer);
+
+    this.renderer.setAttribute(host, 'aria-describedby', tooltipId);
+    this.renderer.setAttribute(host, 'aria-label', tooltip);
+
+    if (!host.hasAttribute('tabindex')) {
+      this.renderer.setAttribute(host, 'tabindex', '0');
+    }
+
+    this.renderer.removeAttribute(host, 'title');
+  }
+}

--- a/frontend/src/app/models/admin-api-models.ts
+++ b/frontend/src/app/models/admin-api-models.ts
@@ -150,6 +150,14 @@ export interface SourceTransformationPlan {
   columnOperations: SourceColumnOperationConfig[];
 }
 
+export interface AdminSourceSchemaField {
+  name: string;
+  displayName?: string | null;
+  dataType: FieldDataType;
+  required: boolean;
+  description?: string | null;
+}
+
 export interface AdminSource {
   id?: number | null;
   code: string;
@@ -162,6 +170,7 @@ export interface AdminSource {
   arrivalTimezone?: string | null;
   arrivalSlaMinutes?: number | null;
   adapterOptions?: string | null;
+  schemaFields?: AdminSourceSchemaField[] | null;
   availableColumns?: string[] | null;
   createdAt?: string | null;
   updatedAt?: string | null;
@@ -198,6 +207,24 @@ export interface TransformationSampleRow {
   externalReference?: string | null;
   rawRecord: Record<string, unknown>;
   canonicalPayload: Record<string, unknown>;
+}
+
+export interface SourceSchemaInferenceRequest {
+  fileType: TransformationSampleFileType;
+  hasHeader: boolean;
+  delimiter?: string;
+  sheetName?: string;
+  sheetNames?: string[];
+  includeAllSheets?: boolean;
+  recordPath?: string;
+  encoding?: string;
+  limit?: number;
+  skipRows?: number;
+}
+
+export interface SourceSchemaInferenceResponse {
+  fields: AdminSourceSchemaField[];
+  sampleRows: Record<string, unknown>[];
 }
 
 export interface TransformationSampleResponse {

--- a/frontend/src/app/services/admin-reconciliation-state.service.ts
+++ b/frontend/src/app/services/admin-reconciliation-state.service.ts
@@ -19,7 +19,9 @@ import {
   SourceTransformationPreviewUploadRequest,
   SourceTransformationPreviewResponse,
   SourceTransformationApplyRequest,
-  SourceTransformationApplyResponse
+  SourceTransformationApplyResponse,
+  SourceSchemaInferenceRequest,
+  SourceSchemaInferenceResponse
 } from '../models/admin-api-models';
 import { ApiService } from './api.service';
 import { NotificationService } from './notification.service';
@@ -294,6 +296,19 @@ export class AdminReconciliationStateService {
       catchError((error) => {
         console.error('Failed to preview transformations from file', error);
         this.notifications.push('Unable to preview transformations from the uploaded file.', 'error');
+        return throwError(() => error);
+      })
+    );
+  }
+
+  inferSourceSchema(
+    payload: SourceSchemaInferenceRequest,
+    file: File
+  ): Observable<SourceSchemaInferenceResponse> {
+    return this.api.inferSourceSchema(payload, file).pipe(
+      catchError((error) => {
+        console.error('Failed to infer schema from sample file', error);
+        this.notifications.push('Unable to infer schema from the uploaded file.', 'error');
         return throwError(() => error);
       })
     );

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -39,7 +39,9 @@ import {
   TransformationSampleResponse,
   TransformationValidationRequest,
   TransformationValidationResponse,
-  ReconciliationLifecycleStatus
+  ReconciliationLifecycleStatus,
+  SourceSchemaInferenceRequest,
+  SourceSchemaInferenceResponse
 } from '../models/admin-api-models';
 
 const BASE_URL = environment.apiUrl;
@@ -291,6 +293,19 @@ export class ApiService {
     formData.append('file', file);
     return this.http.post<SourceTransformationPreviewResponse>(
       `${BASE_URL}/admin/transformations/plan/preview/upload`,
+      formData
+    );
+  }
+
+  inferSourceSchema(
+    payload: SourceSchemaInferenceRequest,
+    file: File
+  ): Observable<SourceSchemaInferenceResponse> {
+    const formData = new FormData();
+    formData.append('request', new Blob([JSON.stringify(payload)], { type: 'application/json' }));
+    formData.append('file', file);
+    return this.http.post<SourceSchemaInferenceResponse>(
+      `${BASE_URL}/admin/source-schemas/infer`,
       formData
     );
   }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,10 +51,10 @@ For faster execution in CI or local smoke testing you can override the defaults:
 - Maker/checker workflow is complete for any run older than 24 hours
 - Export jobs have been generated and completed
 
-The verifier accepts the same `--days` and `--runs-per-day` flags used during seeding so that CI and local runs remain in sync.
+The verifier accepts the same `--days` and `--runs-per-day` flags used during seeding so that CI and local runs remain in sync. When exports are skipped (`--report-format NONE`), pass `--skip-export-check` to avoid an unnecessary failure.
 
 ```bash
-./scripts/verify-historical-seed.sh --days 30 --runs-per-day 3
+./scripts/verify-historical-seed.sh --days 30 --runs-per-day 3 --skip-export-check
 ```
 
 Run the verifier after any code changes that affect ingestion, reconciliation, workflow, or export behaviour.


### PR DESCRIPTION
## Summary
- add a dedicated Source Schema step to the admin wizard and persist schema fields per source
- introduce schema inference API/service so sample uploads populate column metadata shared by transformations and matching
- update docs, examples, automation, and tests to reflect the reordered wizard flow and new seeding commands

## Testing
- ./mvnw test
- npm test -- --watch=false --browsers=ChromeHeadless
- (cd automation/regression && npm test)
- examples/integration-harness/scripts/run_multi_example_e2e.sh
- ./scripts/local-dev.sh bootstrap
- ./scripts/local-dev.sh seed
- ./scripts/seed-historical.sh --days 3 --runs-per-day 1 --report-format NONE
- ./scripts/verify-historical-seed.sh --days 3 --runs-per-day 1 --skip-export-check
