### PR TITLE
docs: refresh wiki for dynamic ingestion and AI adapter

### DIFF
--- a/docs/wiki/Architecture-Review-Briefing.md
+++ b/docs/wiki/Architecture-Review-Briefing.md
@@ -184,7 +184,7 @@ gantt
 ### 10.1 Onboarding & Tooling
 - **Prerequisites:** JDK 17 (LTS), Maven 3.9+, Node.js 18+, optional Docker for MariaDB/LDAP containers.
 - **Bootstrap steps:** `./mvnw dependency:go-offline` for backend, `npm install` for frontend, optional profile overrides via `application-local.yml` and Angular environment files.
-- **Sample data:** `SampleEtlRunner` seeds demo datasets and reconciliation definitions for immediate testing.
+- **Sample data:** `EtlBootstrapper` discovers and executes any bundled `EtlPipeline` implementations (from examples or the integration harness) so demo reconciliations and canonical payloads are available immediately.
 
 ### 10.2 Local Development Flow
 1. Start backend: `cd backend && ./mvnw spring-boot:run` (use `dev` profile for H2 + demo data).

--- a/docs/wiki/Development-Workflow.md
+++ b/docs/wiki/Development-Workflow.md
@@ -44,12 +44,13 @@ graph TD
 2. Download the workbook with `GET /api/exports/runs/{runId}` (supply the JWT in the `Authorization` header).
 3. Store the binary response as `reconciliation-run-<runId>.xlsx` and distribute to stakeholders via secure channels.
 4. Confirm the download was captured in the activity feed (`SystemEventType.REPORT_EXPORT`).
+5. For large, filter-aware extracts use the asynchronous pipeline: `POST /api/reconciliations/{id}/export-jobs` queues a dataset job and `GET /api/export-jobs/{jobId}/download` retrieves the CSV/JSONL/XLSX/PDF artifact once complete.
 
 ### 8.3 Debugging ETL Issues
-1. Start the backend with the default profile; `SampleEtlRunner` logs each pipeline execution at INFO level.
-2. Inspect the application console output (or configured log appender) for pipeline-specific errors (e.g., malformed CSV rows).
-3. Query `source_a_records` and `source_b_records` to verify record counts and key fields; use the H2 console (`/h2-console`) in dev.
-4. To rerun a single pipeline, autowire the component in a Spring test or temporary REST endpoint and call its `run()` method manually.
+1. Start the backend with the default profile; `EtlBootstrapper` logs each discovered `EtlPipeline` execution at INFO level.
+2. Inspect the application console output (or configured log appender) for pipeline-specific errors (e.g., malformed CSV rows or transformation failures).
+3. Query the canonical staging tables (`source_data_batches`, `source_data_records`) to verify record counts and key fields; use the H2 console (`/h2-console`) in dev.
+4. To rerun a single pipeline, autowire the component in a Spring test or temporary REST endpoint and call its `run()` method manually, or trigger ingestion via `/api/admin/reconciliations/{id}/sources/{code}/batches` to exercise the same `SourceIngestionService` path used in production.
 
 ### 8.4 Troubleshooting Authentication
 - Confirm LDAP settings in `application.yml`/`application-local.yml` (`app.security.ldap.*`, `spring.ldap.*`) align with your directory.

--- a/docs/wiki/features.md
+++ b/docs/wiki/features.md
@@ -12,6 +12,7 @@ align stakeholders, and ensure downstream teams understand the breadth of functi
 | **Maker-Checker Workflow** | Approval queue, bulk transitions, audit history | Break actions resolve allowed transitions via `BreakAccessService`, write audit rows, and expose a checker queue API. |
 | **Export Flexibility** | Async dataset jobs, synchronous run exports, metadata-rich payloads | CSV/JSONL/XLSX exports capture filters, hash, row count, and use background jobs to avoid blocking UI threads. |
 | **Ingestion Telemetry** | Source batch uploads with SLAs and activity feed integration | Multipart ingestion endpoint stores batches, checksums, and surfaces success/failure in the activity feed. |
+| **AI-Assisted Ingestion** | LLM document adapter, prompt templates, schema-aware extraction | Unstructured files (PDF, e-mail, office docs) are parsed via Apache Tika and OpenAI then normalised into canonical rows with provenance metadata. |
 
 ## Executive Overview
 - **Audience:** product owners, delivery leads, and stakeholders who need a concise overview of platform value.
@@ -50,6 +51,7 @@ graph TD
 | Analytics | Saved views | Persist personalised grid layouts, share via tokens, and set user defaults. | Analysts |
 | Reporting | Async dataset exports | Queue CSV/JSONL/XLSX jobs with full filter context, poll status, and download artifacts when ready. | Analysts, audit |
 | Reporting | Immediate run exports | Generate XLSX summaries for any run, including filter metadata and audit notes. | Analysts |
+| Ingestion | Unstructured document ingestion | LLM-backed adapter extracts schema-aligned records from PDFs, emails, and office documents using configurable prompts and extraction hints. | Data engineering |
 | Security | LDAP-authenticated access | Authenticate via LDAP, map groups to roles, and enforce dimensional entitlements. | Platform users |
 | Observability | Activity feed | Chronicle runs, workflow transitions, exports, and configuration publishes for support teams. | Support, risk |
 | Observability | Metrics & health checks | Spring Boot actuators and Jacoco coverage thresholds guard code health. | SRE teams |


### PR DESCRIPTION
## Summary
- update the architecture guide to reflect the dynamic matching engine, ingestion adapters (including the LLM path), and export job services
- refresh onboarding and development workflow docs to cover EtlBootstrapper-driven examples, canonical staging tables, and asynchronous exports
- align the database schema reference and feature compendium with current enums and AI-assisted ingestion capabilities

## Testing
- not run (docs-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e01338a898832b964c5a0171d95736