### PR TITLE
chore: upgrade backend to Spring Boot 3.5.6

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Before you start any task, internalize these directives—they govern all work i
 4. **Be cautious with terminal commands.** Evaluate every command before running it to confirm it will terminate on its own. Launch non-terminating commands (like servers) in separate processes and make sure any helper scripts are safe to run unattended.
 
 ## Repository Orientation
-- **Backend:** `backend/` holds the Spring Boot services, matching engine, workflow logic, and ETL pipelines.
+- **Backend:** `backend/` holds the Spring Boot services, matching engine, workflow logic, and ETL pipelines (Spring Boot 3.5.6 on Java 17).
 - **Frontend:** `frontend/` contains the Angular 17 single-page application with standalone components and a shared state service.
 - **Documentation:** Centralized under `docs/wiki`. Start with `docs/wiki/README.md` for navigation, then update specialized guides as needed.
 - **Data Model:** The database schema is critical. Refer to `docs/wiki/Architecture.md` for diagrams.
@@ -32,7 +32,7 @@ Before you start any task, internalize these directives—they govern all work i
 5. **Keep test cases up to date.** Any code change that affects features, workflows, or onboarding must update the relevant test cases in backend, frontend, automation smoke, example integration harness, and bootstrap scripts.
 
 ## Quality Gates
-- **Backend tests:** `cd backend && ./mvnw test`
+- **Backend tests:** `cd backend && ./mvnw test` (requires Java 17+; Spring Boot 3.5.6 workflows remain on JDK 17 by default)
 - **Frontend tests:** `cd frontend && npm test -- --watch=false --browsers=ChromeHeadless`
 - **Automation smoke (Playwright):** `cd automation/regression && npm install && npm test`
 - **Examples integration harness:** `examples/integration-harness/scripts/run_multi_example_e2e.sh`

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.5</version>
+        <version>3.5.6</version>
         <relativePath/>
     </parent>
     <groupId>com.universal</groupId>

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -16,3 +16,11 @@
   - Consequences: Admins author multi-sheet configurations without file conversions, the ingestion SDK derives the
     correct adapter type based on media type, and regression suites can exercise every transformation and matching
     feature in a single run.
+- **ADR: Spring Boot 3.5.6 adoption (2025-10-04)**
+  - Problem: Remaining on Spring Boot 3.2.5 limited framework, security, and servlet container fixes and left us
+    unprepared for Java 21 enablement.
+  - Decision: Upgrade the backend parent BOM to Spring Boot 3.5.6, validate behaviour on Java 17, and execute all
+    quality gates (backend unit tests, Playwright, integration harness, seeding scripts) to confirm runtime parity.
+  - Consequences: The service now inherits Spring Framework 6.2.11, Spring Security 6.5.x, and Hibernate 6.6.29. The
+    application continues to run on Java 17 with virtual threads disabled by default; future work can focus on Java 21
+    adoption instead of dependency catch-up.

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -6,3 +6,7 @@
   - Added the Excel ingestion adapter and corresponding automation fixtures to reconcile six heterogeneous sources.
   - Authored the Global Multi-Asset playbook with diagrams covering business flow, technical hotspots, and usage.
   - Updated the integration harness and ingestion SDK so Excel, CSV, and pipe-delimited feeds can be rehearsed in CI.
+- **Spring Boot 3.5.6 upgrade (2025-10-04)**
+  - Raised the backend parent BOM from Spring Boot 3.2.5 to 3.5.6 and verified the service on Java 17.
+  - Re-ran backend unit tests, Playwright automation, integration harness, bootstrap, and historical seeding to confirm parity.
+  - Documented the procedure in `docs/wiki/spring-boot-upgrade-3-5-6-checklist.md` for future backend refreshes.

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -24,3 +24,11 @@
   troubleshooting.
 - **Mirror preview options**: Adapter metadata submitted during ingestion should reuse the same keys (`hasHeader`,
   `sheetNames`, `includeAllSheets`, `skipRows`) as the admin preview API so configuration and automation remain aligned.
+
+## Spring Boot 3.5 Backend
+- **Upgrade via parent BOM**: Prefer bumping `spring-boot-starter-parent` and letting the managed BOM resolve
+  dependency versions instead of pinning starters manually.
+- **Monitor virtual thread defaults**: Spring Boot 3.5 auto-enables virtual threads on Java 21+. Running on Java 17 keeps
+  them disabled, so no extra configuration was required during the 2025-10-04 upgrade.
+- **Re-run full automation**: Framework upgrades can surface subtle behaviour changes; always run backend tests,
+  Playwright automation, the integration harness, and seed scripts before shipping the change.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -23,3 +23,25 @@
     sheet selection matches the admin configuration.
   - Confirm the workbook size is within the ingestion upload limit and that protected sheets have been unencrypted.
 - **Diagnostics**: Enable `DEBUG` logging for `ExcelIngestionAdapter` to trace sheet discovery and row extraction.
+
+## Angular CLI reports unsupported Node or TypeScript warnings
+- **Symptom**: `ng version` / `ng update` warn about unsupported Node 24.x or emit `TypeScript compiler options 'module'` warnings.
+- **Checklist**:
+  - Install Node 20 via Homebrew (`brew install node@20`) and run Angular commands with `PATH="/opt/homebrew/opt/node@20/bin:$PATH"` to meet the Angular 20 support matrix.
+  - When the CLI forces `module`/`target` to `ES2022`, review project `browserslist`. No action is needed unless custom tsconfig overrides reintroduce incompatible values.
+- **Diagnostics**: `npx ng version` confirms the effective Node + Angular versions after the PATH override.
+
+## `seed-historical.sh` exits with `fail: command not found`
+- **Symptom**: Running the historical seed script immediately aborts with `fail: command not found` on macOS.
+- **Checklist**:
+  - The default `/bin/bash` (v3.2) cannot pass the script's version check. Prefix the command with `PATH="/opt/homebrew/opt/bash/bin:$PATH"` so Bash ≥4 is used.
+  - Ensure `python3`, `curl`, and `jq` are installed—the script validates their presence with `require_command`.
+- **Diagnostics**: Re-run with `bash -x` for detailed tracing once the newer interpreter is on PATH.
+
+## Backend fails after Spring Boot upgrade
+- **Symptom**: The application fails to start immediately after bumping the Spring Boot parent version.
+- **Checklist**:
+  - Confirm the runtime JDK version (`java -version`). Spring Boot 3.5 supports Java 17+, but enabling virtual threads requires Java 21.
+  - Run `./mvnw dependency:tree -Dincludes=org.springframework` to ensure no custom BOM pins older framework modules.
+  - Rebuild the application (`./mvnw clean package`) to refresh the executable JAR layout.
+- **Diagnostics**: Repeat the upgrade with `--debug` logging (`./mvnw --debug spring-boot:run`) to surface missing dependency conflicts or configuration errors.

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -27,6 +27,7 @@ Use these guides to understand common development workflows and learn how to ext
 - **[Ingestion SDK](./ingestion-sdk.md)**: How to build Spring Boot ingestion jars using the reusable SDK, including JDBC and API adapters.
 - **[Automation Regression Guide](../../automation/regression/README.md)**: How to execute the Playwright end-to-end suite and interpret reports.
 - **[Global Multi-Asset Playbook](./Global-Multi-Asset.md)**: Business and technical blueprint for the six-source showcase reconciliation, including diagrams and automation steps.
+- **[Spring Boot 3.5.6 Upgrade Checklist](./spring-boot-upgrade-3-5-6-checklist.md)**: Step-by-step guide for lifting the backend from Spring Boot 3.2.x to 3.5.6 with validation steps and regression hints.
 
 ## 4. Process & Governance
 

--- a/docs/wiki/spring-boot-upgrade-3-5-6-checklist.md
+++ b/docs/wiki/spring-boot-upgrade-3-5-6-checklist.md
@@ -1,0 +1,72 @@
+# Spring Boot 3.2 → 3.5.6 Upgrade Checklist
+
+This playbook guides the Universal Reconciliation Platform backend through consecutive upgrades from Spring Boot 3.2.x to 3.5.6. Follow each stage sequentially, committing at every milestone so you can bisect regressions easily.
+
+**Latest run snapshot (2025-10-04):** Upgraded directly from Spring Boot 3.2.5 to 3.5.6 on Java 17. All backend, automation, and seed suites passed without code changes beyond the parent version bump. Virtual threads remain disabled automatically on Java 17, and the default `ZIP` layout produced the same executable JAR. No additional configuration tweaks were required for Actuator, Security, or data sources.
+
+## References
+- [Spring Boot 3.3 Release Notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.3-Release-Notes)
+- [Spring Boot 3.4 Release Notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.4-Release-Notes)
+- [Spring Boot 3.5 Release Notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.5-Release-Notes)
+- [Spring Framework 6.2 Upgrade Guide](https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-6.2-Release-Notes)
+- [Spring Boot Supported Java Versions](https://docs.spring.io/spring-boot/docs/current/reference/html/getting-started.html#getting-started.system-requirements)
+- [Spring Security 6.5 Migration](https://docs.spring.io/spring-security/reference/servlet/appendix/migration/index.html)
+
+## Before you start
+- [ ] Create a dedicated branch in `backend/` and confirm the working tree is clean (`git status`).
+- [ ] Capture the current build status: `./mvnw -B verify` (or the repo’s backend gate) and note baseline failures.
+- [ ] Export dependency snapshots (`./mvnw -q dependency:tree -Dincludes=org.springframework`) to compare post-upgrade drifts.
+- [ ] Audit third-party starters (Spring LDAP, OAuth2, jjwt, Flyway, database drivers) for compatibility with Spring Boot 3.5.
+- [ ] Confirm CI workers can run with Java 21 (Spring Boot 3.3+ supports Java 17+ but the new build plugins leverage JDK 21 features).
+
+## Environment prerequisites
+- [ ] Upgrade local JDK to at least 21 (use `sdk use java 21.0.x` or the team-approved toolchain). Spring Boot 3.5 still supports Java 17, but the Gradle/Maven plugins require JDK 21 for native image and test slices.
+- [ ] Update Maven to ≥ 3.9.4 (already satisfied in current toolchain) and ensure the Maven wrapper is refreshed (`./mvnw -v`).
+- [ ] Review Dockerfiles or container build images; plan an update if they pin older JDK runtimes.
+
+## Stage 0 – Refresh Spring Boot 3.2.x baseline
+- [ ] Bump the parent `spring-boot-starter-parent` to the latest 3.2 patch (3.2.11 at the time of writing) and re-run tests to ensure a clean baseline before major upgrades.
+- [ ] Execute `./mvnw clean verify` and regression scripts (integration harness, seed scripts) to confirm the baseline remains green; commit as “Spring Boot 3.2.x baseline refresh”.
+
+## Stage 1 – Upgrade to Spring Boot 3.3.x
+- [ ] Update the parent version to `3.3.6` (latest patch) and refresh the Maven wrapper (`./mvnw -N wrapper:wrapper -Dmaven=3.9.9` if required).
+- [ ] Address configuration changes:
+  - Replace deprecated management endpoints configuration if using `management.endpoints.web.exposure.include=*` (3.3 restricts wildcard usage).
+  - Update Actuator metrics tags to opt in via `management.metrics.distribution.percentiles-histogram`.
+  - Opt in to the new BCrypt defaults or pin the legacy strength (`spring.security.password.encoder.strength`).
+- [ ] Replace `SpringApplication.setBannerMode` usages with the builder API (`SpringApplicationBuilder` or `SpringApplication.setBannerMode(Banner.Mode.OFF)` after creation).
+- [ ] Update `@ConfigurationProperties` binding classes if constructor binding is used—Spring Boot 3.3 enforces explicit annotations.
+- [ ] Re-run `./mvnw clean verify`. Investigate test slices failing due to Actuator/Security defaults (Spring Security 6.3).
+- [ ] Run automation suites that depend on backend APIs (integration harness, regression tests) to surface behavioural regressions.
+- [ ] Commit with notes about config and dependency adjustments (“Upgrade backend to Spring Boot 3.3.x”).
+
+## Stage 2 – Upgrade to Spring Boot 3.4.x
+- [ ] Update the parent to `3.4.2`.
+- [ ] Ensure Jakarta EE dependencies align (Spring Boot 3.4 upgrades to Jakarta Validation 3.1 and Servlet 6.1).
+- [ ] Adjust configuration for the new Logback defaults; confirm custom appenders still initialise.
+- [ ] For Testcontainers, upgrade to ≥ 1.20 to align with JDK 21 module changes (if we rely on live containers).
+- [ ] Migrate any use of `RestTemplateBuilder#rootUri` chaining to the new `UriBuilder`. Spring Boot 3.4 deprecates some legacy builder semantics.
+- [ ] Run `./mvnw clean verify` and all scripted gates. Pay attention to LDAP integration tests; Spring Security 6.4 tightened defaults.
+- [ ] Commit with migration notes (“Upgrade backend to Spring Boot 3.4.x”).
+
+## Stage 3 – Upgrade to Spring Boot 3.5.6
+- [ ] Update the parent version to `3.5.6`.
+- [ ] Update `spring-boot-maven-plugin` executions if we opt into the new build info layout (`<layout>ZIP</layout>` default changed). Explicitly set `<layout>ZIP</layout>` if we need to retain legacy behaviour.
+- [ ] Adopt the new `spring.threads.virtual.enabled` default (now `true` for MVC). Decide whether to enable virtual threads globally or pin to `false` for compatibility.
+- [ ] Migrate any `RestClient` usages to the new stable APIs; the old incubator variants were removed.
+- [ ] Re-evaluate Actuator health group configuration: `.status.http-mapping` moved under `management.endpoint.health.status.http-mapping`.
+- [ ] Update Docker/packaging scripts to use JDK 21+ runtime layers if not already done.
+- [ ] Run full quality gates: backend unit/integration tests, frontend tests, Playwright, integration harness, `local-dev` scripts, historical seeding.
+- [ ] Capture key metrics (startup time, health endpoint) for regression comparison.
+- [ ] Commit as “Upgrade backend to Spring Boot 3.5.6”.
+
+## Post-upgrade hardening
+- [ ] Regenerate dependency reports and document new transitive versions (Spring Framework 6.2.1, Spring Security 6.5, Spring Data 2024.1).
+- [ ] Monitor production-like environments for new warnings (virtual threads, Tomcat 10.2 behaviours).
+- [ ] Update CI/CD runner images to ensure `JAVA_HOME` points to 21 when building containers.
+- [ ] Remove temporary compatibility flags once the application stabilises (e.g., `spring.security.filter.dispatcher-types`, old Actuator exposure settings).
+
+## Lessons learned (append as you go)
+- Java 17 still works with Spring Boot 3.5.6; virtual threads stay off without setting `spring.threads.virtual.enabled=false`. Revisit once the runtime moves to Java 21.
+- The `spring-boot-maven-plugin` retained the legacy `ZIP` layout by default; no reconfiguration was required for Docker or the integration harness.
+- Existing LDAP, OAuth2 resource server, and JPA configurations continued to initialize without property changes—still re-run smoke/regression suites to confirm behavioural parity.


### PR DESCRIPTION
## Summary
- bump the backend parent BOM to Spring Boot 3.5.6 and verify compatibility on Java 17
- publish a reusable spring boot upgrade checklist and link it from the wiki
- document the new backend baseline across decisions, milestones, patterns, troubleshooting, and the agents guide

## Testing
- cd backend && ./mvnw clean test
- cd frontend && npm test
- cd frontend && npx ng build
- cd automation/regression && npm test
- examples/integration-harness/scripts/run_multi_example_e2e.sh
- ./scripts/local-dev.sh bootstrap
- ./scripts/local-dev.sh seed
- ./scripts/seed-historical.sh --days 3 --runs-per-day 1 --report-format NONE --ci-mode
- ./scripts/verify-historical-seed.sh --days 3 --runs-per-day 1 --skip-export-check
